### PR TITLE
Update weekly_working_hours.json

### DIFF
--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.json
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.json
@@ -76,8 +76,7 @@
    "fieldname": "shift",
    "fieldtype": "Link",
    "label": "Shift",
-   "options": "Shift Type",
-   "reqd": 1
+   "options": "Shift Type"
   },
   {
    "fieldname": "note",
@@ -136,7 +135,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-05-06 02:24:51.687956",
+ "modified": "2022-05-06 04:01:51.687956",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Weekly Working Hours",


### PR DESCRIPTION
removed mandetory for shift type

There is no requirement for Shift Type to be mandatory