### PR TITLE
Considerer Holidays for Work Hour Report

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -35,38 +35,66 @@ frappe.ui.form.on('Workday', {
 	}, */
 
 	attendance: function(frm){
-		//console.log(frm.doc);
-		let aemployee = frm.doc.employee;
-		let adate = frm.doc.log_date;
-		if(aemployee){
-			frappe.call({
-				method:'hr_addon.hr_addon.api.utils.view_actual_employee_log',
-				args:{aemployee:aemployee,adate:adate}
-			}).done((r)=>{
-				frm.doc.employee_checkins = [];
-				let alog = r.message;
-				frm.set_value("hours_worked",(alog[0].ahour/(60*60)).toFixed(2));
-				frm.set_value("break_hours",(alog[0].bhour/(60*60)).toFixed(2));
-				frm.set_value("total_work_seconds",(alog[0].ahour).toFixed(2));
-				frm.set_value("total_break_seconds",(alog[0].bhour).toFixed(2));
-				frm.set_value("target_hours",alog[0].thour);
-				frm.set_value("total_target_seconds",(alog[0].thour*(60*60)));
-				frm.set_value("expected_break_hours",(alog[0].break_minutes/60));
-				frm.set_value("actual_working_hours",frm.doc.hours_worked - frm.doc.expected_break_hours);
-				let ec = alog[0].items
-				frm.set_value("first_checkin",ec[0].time);
-				frm.set_value("last_checkout",ec[ec.length-1].time);
-				$.each(ec,function(i,e){
-					let nw_checkins = frm.add_child("employee_checkins");
-					nw_checkins.employee_checkin = e.name;
-					nw_checkins.log_type = e.log_type;
-					nw_checkins.log_time = e.time;
-					nw_checkins.skip_auto_attendance= e.skip_auto_attendance;
+		get_hours(frm)
+	},
 
-				});
-				refresh_field("employee_checkins");
-			});
-			
-		}
+	log_date: function(frm){
+		frappe.call({
+			method: "hr_addon.hr_addon.doctype.workday.workday.date_is_in_holiday_list",
+			args: {
+				employee: frm.doc.employee,
+				date: frm.doc.log_date
+			},
+			callback: function(r){
+				console.log("log_date", r);
+				if (r.message == true){
+					frm.set_value("hours_worked", 0)
+					frm.set_value("break_hours", 0)
+					frm.set_value("total_work_seconds", 0)
+					frm.set_value("total_break_seconds", 0)
+					frm.set_value("target_hours", 0)
+					frm.set_value("total_target_seconds", 0)
+					frm.set_value("expected_break_hours", 0)
+					frm.set_value("actual_working_hours", 0)
+				} else {
+					get_hours(frm)
+				}
+			}
+		})
 	}
 });
+
+var get_hours = function(frm){
+	let aemployee = frm.doc.employee;
+	let adate = frm.doc.log_date;
+	if(aemployee){
+		frappe.call({
+			method:'hr_addon.hr_addon.api.utils.view_actual_employee_log',
+			args:{aemployee:aemployee,adate:adate}
+		}).done((r)=>{
+			frm.doc.employee_checkins = [];
+			let alog = r.message;
+			frm.set_value("hours_worked",(alog[0].ahour/(60*60)).toFixed(2));
+			frm.set_value("break_hours",(alog[0].bhour/(60*60)).toFixed(2));
+			frm.set_value("total_work_seconds",(alog[0].ahour).toFixed(2));
+			frm.set_value("total_break_seconds",(alog[0].bhour).toFixed(2));
+			frm.set_value("target_hours",alog[0].thour);
+			frm.set_value("total_target_seconds",(alog[0].thour*(60*60)));
+			frm.set_value("expected_break_hours",(alog[0].break_minutes/60));
+			frm.set_value("actual_working_hours",frm.doc.hours_worked - frm.doc.expected_break_hours);
+			let ec = alog[0].items
+			frm.set_value("first_checkin",ec[0].time);
+			frm.set_value("last_checkout",ec[ec.length-1].time);
+			$.each(ec,function(i,e){
+				let nw_checkins = frm.add_child("employee_checkins");
+				nw_checkins.employee_checkin = e.name;
+				nw_checkins.log_type = e.log_type;
+				nw_checkins.log_time = e.time;
+				nw_checkins.skip_auto_attendance= e.skip_auto_attendance;
+
+			});
+			refresh_field("employee_checkins");
+		});
+		
+	}
+}

--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -46,7 +46,6 @@ frappe.ui.form.on('Workday', {
 				date: frm.doc.log_date
 			},
 			callback: function(r){
-				console.log("log_date", r);
 				if (r.message == true){
 					frm.set_value("hours_worked", 0)
 					frm.set_value("break_hours", 0)
@@ -56,6 +55,9 @@ frappe.ui.form.on('Workday', {
 					frm.set_value("total_target_seconds", 0)
 					frm.set_value("expected_break_hours", 0)
 					frm.set_value("actual_working_hours", 0)
+					frm.set_value("employee_checkins", [])
+					frm.set_value("first_checkin", "")
+					frm.set_value("last_checkout", "")
 				} else {
 					get_hours(frm)
 				}

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -74,6 +74,16 @@ def process_bulk_workday(data):
 		#workday.submit() 
 	
 
+@frappe.whitelist()
+def date_is_in_holiday_list(employee, date):
+	holiday_list = frappe.db.get_value("Employee", employee, "holiday_list")
+	hl_doc = frappe.get_doc("Holiday List", holiday_list)
+	for holiday in hl_doc.holidays:
+		if holiday.holiday_date == frappe.utils.get_datetime(date).date():
+			return True
+	
+	return False
+
 def get_month_map():
 	return frappe._dict({
 		"January": 1,

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -29,47 +29,65 @@ def process_bulk_workday(data):
 		return
 	
 	for date in data.unmarked_days:
-		single = []
-		#single = view_actual_employee_log(data.employee, get_datetime(date))
-		single = get_actual_employee_log_bulk(data.employee, get_datetime(date))
-		c_single = single[0]["items"]		
-		doc_dict = {
-			'doctype': 'Workday',
-			'employee': data.employee,
-			'log_date': get_datetime(date),
-			'company': company,
-			'attendance':single[0]["attendance"],
-			'hours_worked':"{:.2f}".format(single[0]["ahour"]/(60*60)),
-			'break_hours': "{:.2f}".format(single[0]["bhour"]/(60*60)),
-			'expected_break_hours': "{:.2f}".format(single[0]["break_minutes"]/(60)),
-			'total_work_seconds':single[0]["ahour"],
-			'total_break_seconds':single[0]["bhour"],
-			'actual_working_hours': "{:.2f}".format(single[0]["ahour"]/(60*60) - single[0]["break_minutes"]/60)
-		}
-		workday = frappe.get_doc(doc_dict).insert()
-		target_hours = single[0]["thour"]
-		if (workday.status == 'Half Day'):
-			target_hours = (single[0]["thour"])/2
-		if (workday.status == 'On Leave'):
-			target_hours = 0
-		workday.target_hours = target_hours
-		workday.total_target_seconds = target_hours*(60*60)
+		if not date_is_in_holiday_list(data.employee, get_datetime(date)):
+			single = []
+			#single = view_actual_employee_log(data.employee, get_datetime(date))
+			single = get_actual_employee_log_bulk(data.employee, get_datetime(date))
+			c_single = single[0]["items"]		
+			doc_dict = {
+				'doctype': 'Workday',
+				'employee': data.employee,
+				'log_date': get_datetime(date),
+				'company': company,
+				'attendance':single[0]["attendance"],
+				'hours_worked':"{:.2f}".format(single[0]["ahour"]/(60*60)),
+				'break_hours': "{:.2f}".format(single[0]["bhour"]/(60*60)),
+				'expected_break_hours': "{:.2f}".format(single[0]["break_minutes"]/(60)),
+				'total_work_seconds':single[0]["ahour"],
+				'total_break_seconds':single[0]["bhour"],
+				'actual_working_hours': "{:.2f}".format(single[0]["ahour"]/(60*60) - single[0]["break_minutes"]/60)
+			}
+			workday = frappe.get_doc(doc_dict).insert()
+			target_hours = single[0]["thour"]
+			if (workday.status == 'Half Day'):
+				target_hours = (single[0]["thour"])/2
+			if (workday.status == 'On Leave'):
+				target_hours = 0
+			workday.target_hours = target_hours
+			workday.total_target_seconds = target_hours*(60*60)
 
-		# lenght of single must be greater than zero
-		if((not single[0]["items"] is None) and (len(single[0]["items"]) > 0)):
-			workday.first_checkin = c_single[0].time
-			workday.last_checkout = c_single[-1].time
-			
-			for i in range(len(c_single)):
-				row = workday.append("employee_checkins", {
-					'employee_checkin': c_single[i]["name"],
-					'log_type': c_single[i]["log_type"],
-					'log_time': c_single[i]["time"],
-					'skip_auto_attendance': c_single[i]["skip_auto_attendance"],
-					'parent':workday
-				})			
-			
-		workday.save()
+			# lenght of single must be greater than zero
+			if((not single[0]["items"] is None) and (len(single[0]["items"]) > 0)):
+				workday.first_checkin = c_single[0].time
+				workday.last_checkout = c_single[-1].time
+				
+				for i in range(len(c_single)):
+					row = workday.append("employee_checkins", {
+						'employee_checkin': c_single[i]["name"],
+						'log_type': c_single[i]["log_type"],
+						'log_time': c_single[i]["time"],
+						'skip_auto_attendance': c_single[i]["skip_auto_attendance"],
+						'parent':workday
+					})			
+			workday.save()
+		else:
+			doc_dict = {
+				'doctype': 'Workday',
+				'employee': data.employee,
+				'log_date': get_datetime(date),
+				'company': company,
+				'attendance':"",
+				'hours_worked':0,
+				'break_hours':0,
+				'expected_break_hours':0,
+				'total_work_seconds':0,
+				'total_break_seconds':0,
+				'actual_working_hours':0,
+				'target_hours': 0,
+				'total_target_seconds': 0,
+				'employee_checkins': []
+			}
+			workday = frappe.get_doc(doc_dict).insert()
 			
 		#workday.submit() 
 	


### PR DESCRIPTION
Solving https://github.com/phamos-eu/HR-Addon/issues/33

Now the Holidays set via "Holiday List" are considered while creating the Workday. If the Workday's date is one in Holiday List, then all Workday's fields are zeroed or emptied, in order not to affect the Work Hour Report.

Here is how it works for a single Workday:
![Kazam_screencast_00039](https://github.com/phamos-eu/HR-Addon/assets/6966715/478c6c7f-f996-4247-9d0d-707239f46829)

Here is how it works for bulk processing:
![Kazam_screencast_00040](https://github.com/phamos-eu/HR-Addon/assets/6966715/18f899aa-acb9-4ed5-b062-b7bf9bd5288d)
