### PR TITLE
No break hours if target hours is less than 6 hours

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -80,10 +80,16 @@ def view_actual_employee_log(aemployee, adate):
         
     # create list
     employee_default_work_hour = get_employee_default_work_hour(aemployee,adate)[0]
+    break_minutes = employee_default_work_hour.break_minutes
+    wwh = frappe.db.get_list(doctype="Weekly Working Hours", filters={"employee": aemployee}, fields=["name", "no_break_hours"])
+    no_break_hours = True if len(wwh) > 0 and wwh[0]["no_break_hours"] == 1 else False
+    if no_break_hours:
+        if employee_default_work_hour.hours < 6:
+            break_minutes = 0
     new_workday = []
     new_workday.append({
         "thour": employee_default_work_hour.hours,
-        "break_minutes": employee_default_work_hour.break_minutes,
+        "break_minutes": break_minutes,
         "ahour": hours_worked,
         "nbreak": 0,
         "attendance": weekly_day_hour[0].attendance if len(weekly_day_hour) > 0 else "",        

--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.json
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.json
@@ -20,6 +20,7 @@
   "hours",
   "section_break_11",
   "total_work_hours",
+  "no_break_hours",
   "column_break_14",
   "total_hours_time",
   "amended_from",
@@ -131,11 +132,17 @@
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company"
+  },
+  {
+   "default": "0",
+   "fieldname": "no_break_hours",
+   "fieldtype": "Check",
+   "label": "No break hours if target hours is less than 6 hours"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-05-09 17:28:24.192027",
+ "modified": "2023-07-04 11:38:50.406939",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Weekly Working Hours",

--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -110,9 +110,8 @@ var get_hours = function(frm){
 				nw_checkins.log_type = e.log_type;
 				nw_checkins.log_time = e.time;
 				nw_checkins.skip_auto_attendance= e.skip_auto_attendance;
-				});
 				refresh_field("employee_checkins");
 			});
-		}
+		})
 	}
-});
+}


### PR DESCRIPTION
Issue #41 

Tasks:
- Add a "No break hours if target hours is less than 6 hours" checkbox field in Weekly Working Hours
![Captura de pantalla de 2023-07-04 16-08-45](https://github.com/phamos-eu/HR-Addon/assets/6966715/33724cbe-02d8-4a2f-85ce-c5b6fcc0b995)

- Add function to process this condition

Using the Workday form:
![Kazam_screencast_00047](https://github.com/phamos-eu/HR-Addon/assets/6966715/861e5328-c7b0-47b4-a31f-74ce0828887f)

Using the "Process Workdays" function:
![Kazam_screencast_00048](https://github.com/phamos-eu/HR-Addon/assets/6966715/70d8c6a9-d791-47af-be95-2d1ed2bc646f)
