### PR TITLE
Use hours_worked instead of target_hours

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -84,7 +84,7 @@ def view_actual_employee_log(aemployee, adate):
     wwh = frappe.db.get_list(doctype="Weekly Working Hours", filters={"employee": aemployee}, fields=["name", "no_break_hours"])
     no_break_hours = True if len(wwh) > 0 and wwh[0]["no_break_hours"] == 1 else False
     if no_break_hours:
-        if employee_default_work_hour.hours < 6:
+        if hours_worked/60/60 < 6:
             break_minutes = 0
     new_workday = []
     new_workday.append({

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -60,12 +60,13 @@ def process_bulk_workday(data):
 				workday.expected_break_hours = 0
 				workday.total_break_seconds = 0
 				workday.actual_working_hours = 0
-			elif workday.target_hours < 6:
+			if float(workday.hours_worked) < 6:
 				wwh = frappe.db.get_list(doctype="Weekly Working Hours", filters={"employee": workday.employee}, fields=["name", "no_break_hours"])
 				no_break_hours = True if len(wwh) > 0 and wwh[0]["no_break_hours"] == 1 else False
 				if no_break_hours:
 					workday.expected_break_hours = 0
 					workday.total_break_seconds = 0
+					workday.actual_working_hours = workday.hours_worked
 
 			# lenght of single must be greater than zero
 			if((not single[0]["items"] is None) and (len(single[0]["items"]) > 0)):


### PR DESCRIPTION
issue #41

This is the problem:
![imagen](https://github.com/phamos-eu/HR-Addon/assets/6966715/e0fc2814-e734-4b4e-a1c9-8f14b3c5f76a)


That is: the `target_hours` is taken as the value for asking if it is less than 6 hours, but it should be the `hours_worked`.

After changing that, this is how it works (using the Workday form):
![Kazam_screencast_00052](https://github.com/phamos-eu/HR-Addon/assets/6966715/9833d75d-e1ed-4612-8103-eb7fb7d5998d)

and using the "Process Workday" function:
![Kazam_screencast_00053](https://github.com/phamos-eu/HR-Addon/assets/6966715/b6031eb0-e5bc-4579-8ee0-413a3a359c19)
