### PR TITLE
Set Target Hours to Zero when date is holiday

### DIFF
--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.json
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.json
@@ -21,6 +21,7 @@
   "section_break_11",
   "total_work_hours",
   "no_break_hours",
+  "set_target_hours_to_zero_when_date_is_holiday",
   "column_break_14",
   "total_hours_time",
   "amended_from",
@@ -138,11 +139,17 @@
    "fieldname": "no_break_hours",
    "fieldtype": "Check",
    "label": "No break hours if target hours is less than 6 hours"
+  },
+  {
+   "default": "0",
+   "fieldname": "set_target_hours_to_zero_when_date_is_holiday",
+   "fieldtype": "Check",
+   "label": "Set Target Hours to Zero when date is holiday"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-07-04 11:38:50.406939",
+ "modified": "2023-07-27 09:16:56.101160",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Weekly Working Hours",

--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -40,7 +40,7 @@ frappe.ui.form.on('Workday', {
 
 	log_date: function(frm){
 		frappe.call({
-			method: "hr_addon.hr_addon.doctype.workday.workday.date_is_in_holiday_list",
+			method: "hr_addon.hr_addon.api.utils.date_is_in_holiday_list",
 			args: {
 				employee: frm.doc.employee,
 				date: frm.doc.log_date

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -10,7 +10,7 @@ from frappe.utils import cint, cstr, formatdate, get_datetime, getdate, nowdate,
 from frappe.utils.data import date_diff
 from datetime import date,datetime
 
-from hr_addon.hr_addon.api.utils import view_actual_employee_log,get_actual_employee_log_bulk
+from hr_addon.hr_addon.api.utils import view_actual_employee_log, get_actual_employee_log_bulk, date_is_in_holiday_list
 
 
 class Workday(Document):
@@ -103,16 +103,6 @@ def process_bulk_workday(data):
 		#workday.submit() 
 		workday.save()
 	
-
-@frappe.whitelist()
-def date_is_in_holiday_list(employee, date):
-	holiday_list = frappe.db.get_value("Employee", employee, "holiday_list")
-	hl_doc = frappe.get_doc("Holiday List", holiday_list)
-	for holiday in hl_doc.holidays:
-		if holiday.holiday_date == frappe.utils.get_datetime(date).date():
-			return True
-
-	return False
 
 
 def get_month_map():

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -29,76 +29,64 @@ def process_bulk_workday(data):
 		return
 	
 	for date in data.unmarked_days:
-		if not date_is_in_holiday_list(data.employee, get_datetime(date)):
-			single = []
-			#single = view_actual_employee_log(data.employee, get_datetime(date))
-			single = get_actual_employee_log_bulk(data.employee, get_datetime(date))
-			c_single = single[0]["items"]		
-			doc_dict = {
-				'doctype': 'Workday',
-				'employee': data.employee,
-				'log_date': get_datetime(date),
-				'company': company,
-				'attendance':single[0]["attendance"],
-				'hours_worked':"{:.2f}".format(single[0]["ahour"]/(60*60)),
-				'break_hours': "{:.2f}".format(single[0]["bhour"]/(60*60)),
-				'expected_break_hours': "{:.2f}".format(single[0]["break_minutes"]/(60)),
-				'total_work_seconds':single[0]["ahour"],
-				'total_break_seconds':single[0]["bhour"],
-				'actual_working_hours': "{:.2f}".format(single[0]["ahour"]/(60*60) - single[0]["break_minutes"]/60)
-			}
-			workday = frappe.get_doc(doc_dict).insert()
-			target_hours = single[0]["thour"]
-			if (workday.status == 'Half Day'):
-				target_hours = (single[0]["thour"])/2
-			if (workday.status == 'On Leave'):
-				target_hours = 0
-			workday.target_hours = target_hours
-			workday.total_target_seconds = target_hours*(60*60)
+		single = []
+		#single = view_actual_employee_log(data.employee, get_datetime(date))
+		single = get_actual_employee_log_bulk(data.employee, get_datetime(date))
+		c_single = single[0]["items"]		
+		doc_dict = {
+			'doctype': 'Workday',
+			'employee': data.employee,
+			'log_date': get_datetime(date),
+			'company': company,
+			'attendance':single[0]["attendance"],
+			'hours_worked':"{:.2f}".format(single[0]["ahour"]/(60*60)),
+			'break_hours': "{:.2f}".format(single[0]["bhour"]/(60*60)),
+			'expected_break_hours': "{:.2f}".format(single[0]["break_minutes"]/(60)),
+			'total_work_seconds':single[0]["ahour"],
+			'total_break_seconds':single[0]["bhour"],
+			'actual_working_hours': "{:.2f}".format(single[0]["ahour"]/(60*60) - single[0]["break_minutes"]/60)
+		}
+		workday = frappe.get_doc(doc_dict).insert()
+		target_hours = single[0]["thour"]
+		if (workday.status == 'Half Day'):
+			target_hours = (single[0]["thour"])/2
+		if (workday.status == 'On Leave'):
+			target_hours = 0
+		workday.target_hours = target_hours
+		workday.total_target_seconds = target_hours*(60*60)
 
-			if workday.target_hours == 0:
+		if workday.target_hours == 0:
+			workday.expected_break_hours = 0
+			workday.total_break_seconds = 0
+			workday.actual_working_hours = 0
+		if float(workday.hours_worked) < 6:
+			wwh = frappe.db.get_list(doctype="Weekly Working Hours", filters={"employee": workday.employee}, fields=["name", "no_break_hours"])
+			no_break_hours = True if len(wwh) > 0 and wwh[0]["no_break_hours"] == 1 else False
+			if no_break_hours:
 				workday.expected_break_hours = 0
 				workday.total_break_seconds = 0
-				workday.actual_working_hours = 0
-			if float(workday.hours_worked) < 6:
-				wwh = frappe.db.get_list(doctype="Weekly Working Hours", filters={"employee": workday.employee}, fields=["name", "no_break_hours"])
-				no_break_hours = True if len(wwh) > 0 and wwh[0]["no_break_hours"] == 1 else False
-				if no_break_hours:
-					workday.expected_break_hours = 0
-					workday.total_break_seconds = 0
-					workday.actual_working_hours = workday.hours_worked
+				workday.actual_working_hours = workday.hours_worked
 
-			# lenght of single must be greater than zero
-			if((not single[0]["items"] is None) and (len(single[0]["items"]) > 0)):
-				workday.first_checkin = c_single[0].time
-				workday.last_checkout = c_single[-1].time
-				
-				for i in range(len(c_single)):
-					row = workday.append("employee_checkins", {
-						'employee_checkin': c_single[i]["name"],
-						'log_type': c_single[i]["log_type"],
-						'log_time': c_single[i]["time"],
-						'skip_auto_attendance': c_single[i]["skip_auto_attendance"],
-						'parent':workday
-					})			
-		else:
-			doc_dict = {
-				'doctype': 'Workday',
-				'employee': data.employee,
-				'log_date': get_datetime(date),
-				'company': company,
-				'attendance':"",
-				'hours_worked':0,
-				'break_hours':0,
-				'expected_break_hours':0,
-				'total_work_seconds':0,
-				'total_break_seconds':0,
-				'actual_working_hours':0,
-				'target_hours': 0,
-				'total_target_seconds': 0,
-				'employee_checkins': []
-			}
-			workday = frappe.get_doc(doc_dict).insert()
+		# lenght of single must be greater than zero
+		if((not single[0]["items"] is None) and (len(single[0]["items"]) > 0)):
+			workday.first_checkin = c_single[0].time
+			workday.last_checkout = c_single[-1].time
+			
+			for i in range(len(c_single)):
+				row = workday.append("employee_checkins", {
+					'employee_checkin': c_single[i]["name"],
+					'log_type': c_single[i]["log_type"],
+					'log_time': c_single[i]["time"],
+					'skip_auto_attendance': c_single[i]["skip_auto_attendance"],
+					'parent':workday
+				})
+		if date_is_in_holiday_list(data.employee, get_datetime(date)):
+			wwh = frappe.db.get_list(doctype="Weekly Working Hours", filters={"employee": data.employee}, fields=["name", "no_break_hours", "set_target_hours_to_zero_when_date_is_holiday"])
+			if len(wwh) > 0 and wwh[0]["set_target_hours_to_zero_when_date_is_holiday"] == 1:
+				workday.actual_working_hours = float(workday.actual_working_hours) + float(workday.expected_break_hours)
+				workday.expected_break_hours = 0
+				workday.target_hours = 0
+				workday.total_target_seconds = 0
 			
 		#workday.submit() 
 		workday.save()


### PR DESCRIPTION
issue #47

Changes:
- Added a checkbox field in "Weekly Working Hour", called "Set Target Hours to Zero when date is holiday".
- If this is enabled and the Workday's Date is within the Holiday list, then the Workday's Target Hours should be set to zero.

Here is how it works:
![Kazam_screencast_00059](https://github.com/phamos-eu/HR-Addon/assets/6966715/3441c83d-8c55-4a21-9bea-3df3dfbcf245)

Work Hour Report:
![Captura de pantalla de 2023-07-27 12-13-23](https://github.com/phamos-eu/HR-Addon/assets/6966715/c1b9fbe1-022e-48e0-9b7c-20099bf79efe)
(for the date 26-07-2023 the target seconds column is zero, so the Diff is positive)

ToDo:
- [x] Apply the same function for the Bulk Processing (check https://github.com/phamos-eu/HR-Addon/pull/48#issuecomment-1653990278)