### PR TITLE
export icalendar file on_change hook

### DIFF
--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -188,3 +188,9 @@ user_data_fields = [
 # translated_search_doctypes = []
 
 required_apps = ["hrms"]
+
+doc_events = {
+    "Leave Application": {
+        "on_change": "hr_addon.hr_addon.api.export_calendar.export_calendar",
+    }
+}

--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -1,0 +1,41 @@
+import io
+import frappe
+from icalendar import Event, Calendar
+from datetime import datetime
+from frappe.utils.file_manager import save_file
+
+def generate_leave_ical_file(leave_applications):
+    cal = Calendar()
+
+    for leave_application in leave_applications:
+        event = Event()
+
+        # Extract data from the Leave Application document
+        start_date = leave_application.get('from_date')
+        end_date = leave_application.get('to_date')
+        employee_name = leave_application.get('employee')
+        leave_type = leave_application.get('leave_type')
+        description = leave_application.get('description')
+
+        event.add('dtstart', start_date)
+        event.add('dtend', end_date)
+        event.add('summary', f'{employee_name} - {leave_type}')
+        event.add('description', description)
+
+        cal.add_component(event)
+
+    # Generate the iCalendar data
+    ical_data = cal.to_ical()
+
+    return ical_data
+
+def export_calendar(doc, method=None):
+    if doc.status == "Approved":
+        leave_applications = frappe.db.get_list("Leave Application", 
+                        filters={"status": "Approved"},
+                        fields=["from_date", "to_date", "employee", "leave_type", "description"])
+        ical_data = generate_leave_ical_file(leave_applications)
+
+        # Save the iCalendar data as a File document
+        file_name = "Urlaubskalender.ics"  # Set the desired filename here
+        save_file(file_name, ical_data, dt="Leave Application", dn=doc.name, is_private=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # frappe -- https://github.com/frappe/frappe is installed via 'bench init'
 #paytmchecksum~=1.7.0
 #hrms
+icalendar


### PR DESCRIPTION
issue #50

This is how it works:
![Kazam_screencast_00061](https://github.com/phamos-eu/HR-Addon/assets/6966715/ca54cf15-f1ab-4c00-b3ee-769c8ff02606)

This is the generated file (the original file was compressed into .zip because GitHub does not allow .ics files):
[Urlaubskalender499864.zip](https://github.com/phamos-eu/HR-Addon/files/12216605/Urlaubskalender499864.zip)

Observation:
- The export function will be triggered when there is a change in a Leave Application document, particularly when it is in a "Approved" status.
- The File is attached to the last Leave Application in "Approved" status, which triggered the function call.
- The generated filename is always unique, because the content's hash is suffixed to the original filename. This behavior cannot be changed using the standard `frappe.utils.file_manager.save_file` function. If we always need the same filename, then we should follow a different function and this may take a while to make it working appropriately.
