### PR TITLE
Feature/50 export icalendar

### DIFF
--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -13,7 +13,7 @@ def generate_leave_ical_file(leave_applications):
         # Extract data from the Leave Application document
         start_date = leave_application.get('from_date')
         end_date = leave_application.get('to_date')
-        employee_name = leave_application.get('employee')
+        employee_name = leave_application.get('employee_name')
         leave_type = leave_application.get('leave_type')
         description = leave_application.get('description')
 
@@ -33,9 +33,9 @@ def export_calendar(doc, method=None):
     if doc.status == "Approved":
         leave_applications = frappe.db.get_list("Leave Application", 
                         filters={"status": "Approved"},
-                        fields=["from_date", "to_date", "employee", "leave_type", "description"])
+                        fields=["from_date", "to_date", "employee_name", "leave_type", "description"])
         ical_data = generate_leave_ical_file(leave_applications)
 
         # Save the iCalendar data as a File document
         file_name = "Urlaubskalender.ics"  # Set the desired filename here
-        save_file(file_name, ical_data, dt="Leave Application", dn=doc.name, is_private=1)
+        save_file(file_name, ical_data, dt="Leave Application", dn=doc.name, is_private=0)

--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -30,6 +30,9 @@ def generate_leave_ical_file(leave_applications):
     return ical_data
 
 def export_calendar(doc, method=None):
+    """
+    This function is triggered when a Leave Application is created/changed/updated.
+    """
     if doc.status == "Approved":
         leave_applications = frappe.db.get_list("Leave Application", 
                         filters={"status": "Approved"},
@@ -38,4 +41,25 @@ def export_calendar(doc, method=None):
 
         # Save the iCalendar data as a File document
         file_name = "Urlaubskalender.ics"  # Set the desired filename here
-        save_file(file_name, ical_data, dt="Leave Application", dn=doc.name, is_private=0)
+        create_file(file_name, ical_data, doc.name)
+
+
+def create_file(file_name, file_content, doc_name):
+    """
+    Creates a file in public folder and also a Frappe's File document and attatch it to the Leave Application.
+    """
+    
+    file_path = "{}/public/files/{}".format(frappe.utils.get_site_path(), file_name)
+    with open(file_path, 'wb') as ical_file:
+        ical_file.write(file_content)
+
+    # Save the file in the Frappe File document
+    file_doc = frappe.get_doc({
+        "doctype": "File",
+        "file_name": file_name,
+        "file_url": "/files/{}".format(file_name),
+        "is_private": 0,
+        "attached_to_doctype": "Leave Application",
+        "attached_to_name": doc_name
+    })
+    file_doc.save()


### PR DESCRIPTION
What is included:
- use `employee_name` instead of `employee`
- make the `.ics` file always public
- always create the `.ics` file with the same name. 

In this way, the file will be accessible via the same URL: `<BASE_URL>/files/Urlaubskalender.ics`

![Captura de pantalla de 2023-08-01 11-47-26](https://github.com/phamos-eu/HR-Addon/assets/6966715/44c295e7-3626-4c2b-af81-b607d3154acd)
