### PR TITLE
Add field to settings and generate random filename

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -5,4 +5,29 @@ frappe.ui.form.on('HR Addon Settings', {
 	// refresh: function(frm) {
 
 	// }
+
+	validate: function(frm){
+		if (frm.doc.name_of_calendar_export_ics_file.length == 0){
+			const randomString = generateRandomString(24);
+			frm.set_value("name_of_calendar_export_ics_file", randomString)
+		}
+	},
+
+	after_save: function(frm){
+		if (frm.doc.name_of_calendar_export_ics_file.length < 24){
+			frappe.msgprint("The filename is less than 24 characters. Please, consider to have a longer filename or leave it empty to get a random filename.")
+		}
+	}
 });
+
+function generateRandomString(length) {
+	const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	let randomString = '';
+	
+	for (let i = 0; i < length; i++) {
+	  const randomIndex = Math.floor(Math.random() * characters.length);
+	  randomString += characters.charAt(randomIndex);
+	}
+	
+	return randomString;
+}

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -8,7 +8,8 @@
  "field_order": [
   "general_section",
   "runapp",
-  "allow_bulk_processing"
+  "allow_bulk_processing",
+  "name_of_calendar_export_ics_file"
  ],
  "fields": [
   {
@@ -27,12 +28,18 @@
    "fieldname": "allow_bulk_processing",
    "fieldtype": "Check",
    "label": "Allow Bulk Processing"
+  },
+  {
+   "description": "Just the filename without the extension .ics",
+   "fieldname": "name_of_calendar_export_ics_file",
+   "fieldtype": "Data",
+   "label": "Name of calendar export ICS file"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-05-13 22:53:32.840880",
+ "modified": "2023-08-23 09:01:11.883966",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",


### PR DESCRIPTION
issue #58

That is included:
- Add a "Name of calendar export ICS file" field to HR Addon Settings doctype.
- Generate a random filename if the field is not set.
- Show a warning message if the filename is less than 24 characters.

![Kazam_screencast_00066](https://github.com/phamos-eu/HR-Addon/assets/6966715/dc34e0f6-3f2c-4dfa-b8ca-692b5edbe7ae)
