### PR TITLE
Feature/58 hide link to ics file

### DIFF
--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -44,7 +44,8 @@ def export_calendar(doc, method=None):
         ical_data = generate_leave_ical_file(leave_applications)
 
         # Save the iCalendar data as a File document
-        file_name = "Urlaubskalender.ics"  # Set the desired filename here
+        file_name = frappe.db.get_single_value("HR Addon Settings", "name_of_calendar_export_ics_file")
+        file_name = "{}.ics".format(file_name)  # Set the desired filename here
         create_file(file_name, ical_data, doc.name)
 
 

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -1,8 +1,17 @@
 # Copyright (c) 2022, Jide Olayinka and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe, os
 from frappe.model.document import Document
 
 class HRAddonSettings(Document):
-	pass
+	def before_save(self):
+		# remove the old ics file
+		old_doc = self.get_doc_before_save()
+		old_file_name = old_doc.name_of_calendar_export_ics_file
+		if old_file_name != self.name_of_calendar_export_ics_file:
+			os.remove("{}/public/files/{}.ics".format(frappe.utils.get_site_path(), old_file_name))
+
+		# remove also the Urlaubskalender.ics, if exist
+		if os.path.exists("{}/public/files/Urlaubskalender.ics".format(frappe.utils.get_site_path())):
+			os.remove("{}/public/files/Urlaubskalender.ics".format(frappe.utils.get_site_path()))


### PR DESCRIPTION
What is included:
- save ics file with the new filename
![Kazam_screencast_00000](https://github.com/phamos-eu/HR-Addon/assets/6966715/309f827a-d97a-4cb4-8f7d-feebb1533c09)

- remove old ics files when changing the filename
![Kazam_screencast_00001](https://github.com/phamos-eu/HR-Addon/assets/6966715/cca00727-f993-40e0-b367-909403f442fb)

- remove Urlaubskalender.ics file if exists (to run this process just change the filename in the HR Addon Settings and hit save)