### PR TITLE
Add a day for one-day leave applications

### DIFF
--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -13,8 +13,7 @@ def generate_leave_ical_file(leave_applications):
         # Extract data from the Leave Application document
         start_date = leave_application.get('from_date')
         end_date = leave_application.get('to_date')
-        if start_date != end_date:
-            end_date += frappe.utils.datetime.timedelta(days=1)
+        end_date += frappe.utils.datetime.timedelta(days=1)
         employee_name = leave_application.get('employee_name')
         leave_type = leave_application.get('leave_type')
         description = leave_application.get('description')


### PR DESCRIPTION
## Issue
We still have a small issue in our calendar.
Calendar view = Correct
Appointments with more than one day = Correct
Appointments with only one day: 
The end date jumps back one day, but is displayed correctly in the calendar overview.
I have summarized everything on an attached image. 

![004](https://github.com/phamos-eu/HR-Addon/assets/6966715/3f4c1f60-c14a-44bb-a834-c305a72445f2)

## Solution
Add +1 day to `end_date` also for one-day leave applications