### PR TITLE
Changable ICS folder

### DIFF
--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -1,4 +1,4 @@
-import io
+import io, os
 import frappe
 from icalendar import Event, Calendar
 from datetime import datetime
@@ -55,9 +55,11 @@ def export_calendar(doc, method=None):
 
 def create_file(file_name, file_content, doc_name):
     """
-    Creates a file in public folder.
+    Creates a file in user defined folder
     """
-
-    file_path = "{}/public/files/{}".format(frappe.utils.get_site_path(), file_name)
+    folder_path = frappe.db.get_single_value("HR Addon Settings", "ics_folder_path")
+    if not folder_path:
+        folder_path = "{}/public/files/".format(frappe.utils.get_site_path())
+    file_path = os.path.join(folder_path, file_name)
     with open(file_path, 'wb') as ical_file:
         ical_file.write(file_content)

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -9,7 +9,8 @@
   "general_section",
   "runapp",
   "allow_bulk_processing",
-  "name_of_calendar_export_ics_file"
+  "name_of_calendar_export_ics_file",
+  "ics_folder_path"
  ],
  "fields": [
   {
@@ -34,12 +35,18 @@
    "fieldname": "name_of_calendar_export_ics_file",
    "fieldtype": "Data",
    "label": "Name of calendar export ICS file"
+  },
+  {
+   "description": "Absolute Path of the folder in which the ICS file will be saved, for example: /home/xxxxxxxxxx/owncloud/calendar/. Make sure this folder is writable by frappe user. Leave this field empty if you want to make the file public.",
+   "fieldname": "ics_folder_path",
+   "fieldtype": "Data",
+   "label": "ICS folder path"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-08-28 11:33:27.539168",
+ "modified": "2023-10-05 14:23:55.630571",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",


### PR DESCRIPTION
issue #67 

This PR allows the user to define a folder path in which to save the ICS file.

IMPORTANT: the folder should be writable by the frappe linux user. Otherwise, the you will get an error like "PermissionError: [Errno 13] Permission denied".

![Kazam_screencast_00116](https://github.com/phamos-eu/HR-Addon/assets/6966715/83d2b811-92f5-4fb8-a367-9a5bf7732bf5)
