### PR TITLE
migrate develop to version-14 20231009

### DIFF
--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -20,10 +20,15 @@ def generate_leave_ical_file(leave_applications):
         if not description:
             description = ""
 
+        uid = leave_application.name
+        if uid.count("-") == 4:
+            uid = uid[:-2]
+
         event.add('dtstart', start_date)
         event.add('dtend', end_date)
         event.add('summary', f'{employee_name} - {leave_type}')
         event.add('description', description)
+        event.add("uid", uid)
 
         cal.add_component(event)
 
@@ -39,7 +44,7 @@ def export_calendar(doc, method=None):
     if doc.status == "Approved":
         leave_applications = frappe.db.get_list("Leave Application", 
                         filters={"status": "Approved"},
-                        fields=["from_date", "to_date", "employee_name", "leave_type", "description"])
+                        fields=["name", "from_date", "to_date", "employee_name", "leave_type", "description"])
         ical_data = generate_leave_ical_file(leave_applications)
 
         # Save the iCalendar data as a File document

--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -1,4 +1,4 @@
-import io
+import io, os
 import frappe
 from icalendar import Event, Calendar
 from datetime import datetime
@@ -55,9 +55,11 @@ def export_calendar(doc, method=None):
 
 def create_file(file_name, file_content, doc_name):
     """
-    Creates a file in public folder.
+    Creates a file in user defined folder
     """
-
-    file_path = "{}/public/files/{}".format(frappe.utils.get_site_path(), file_name)
+    folder_path = frappe.db.get_single_value("HR Addon Settings", "ics_folder_path")
+    if not folder_path:
+        folder_path = "{}/public/files/".format(frappe.utils.get_site_path())
+    file_path = os.path.join(folder_path, file_name)
     with open(file_path, 'wb') as ical_file:
         ical_file.write(file_content)

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -9,7 +9,8 @@
   "general_section",
   "runapp",
   "allow_bulk_processing",
-  "name_of_calendar_export_ics_file"
+  "name_of_calendar_export_ics_file",
+  "ics_folder_path"
  ],
  "fields": [
   {
@@ -34,12 +35,18 @@
    "fieldname": "name_of_calendar_export_ics_file",
    "fieldtype": "Data",
    "label": "Name of calendar export ICS file"
+  },
+  {
+   "description": "Absolute Path of the folder in which the ICS file will be saved, for example: /home/xxxxxxxxxx/owncloud/calendar/. Make sure this folder is writable by frappe user. Leave this field empty if you want to make the file public.",
+   "fieldname": "ics_folder_path",
+   "fieldtype": "Data",
+   "label": "ICS folder path"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-08-28 11:33:27.539168",
+ "modified": "2023-10-05 14:23:55.630571",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",


### PR DESCRIPTION
Die Kalender-ICS-Datei enthält nun bei jedem Ereignis eine UID.
Der Speicherort der Datei kann frei gewählt werden und unter HR Addon Settings als Pfad eingegeben werden.
Beide Neuerungen wurden getestet und werden jetzt in die normale Vollversion übernommen,

https://github.com/phamos-eu/HR-Addon/issues/67