### PR TITLE
Include cancelled document in the ics file

### DIFF
--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -192,5 +192,6 @@ required_apps = ["hrms"]
 doc_events = {
     "Leave Application": {
         "on_change": "hr_addon.hr_addon.api.export_calendar.export_calendar",
+		"on_cancel": "hr_addon.hr_addon.api.export_calendar.export_calendar"
     }
 }


### PR DESCRIPTION
issue #70 

- The ICS file must also be regenerated when a previously booked appointment is cancelled.
- The cancelled entry with its UID should now have the name or name prefix CANCELLED
- If a leave application was cancelled and the amended and submitted again, there will be two documents: for example LA-0001 and LA-0001-1. The first one is not included into the ICS file because was replaced by the other one.

![Kazam_screencast_00131](https://github.com/phamos-eu/HR-Addon/assets/6966715/38018dc5-598d-473d-b018-52d28b5a4b95)

