### PR TITLE
Develop

### DIFF
--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -192,5 +192,6 @@ required_apps = ["hrms"]
 doc_events = {
     "Leave Application": {
         "on_change": "hr_addon.hr_addon.api.export_calendar.export_calendar",
+		"on_cancel": "hr_addon.hr_addon.api.export_calendar.export_calendar"
     }
 }


### PR DESCRIPTION
Cancelled Leave Application are now also listed in the calendar. Duplicate entries are prevented. (If a canceled appointment is replaced by a new one, the canceled appointment is no longer exported in the leave calendar and the new entry gets the old UID).
If an entry is cancelled, it is marked with the prefix Cancelled in its name.