### PR TITLE
download ics file when even if the folder is not set

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -20,11 +20,16 @@ class HRAddonSettings(Document):
 @frappe.whitelist()
 def download_ics_file():
 	settings = frappe.get_doc("HR Addon Settings")
+
+	file_name = ""
 	if settings.ics_folder_path:
 		file_name = os.path.join(settings.ics_folder_path, settings.name_of_calendar_export_ics_file + ".ics")
-		if os.path.exists(file_name):
-			with open(file_name, 'rb') as file:
-				file_content = file.read()
-			return file_content
-		else:
-			frappe.throw(f"File '{file_name}' not found.")
+	else:
+		file_name = "{}/public/files/{}.ics".format(frappe.utils.get_site_path(), settings.name_of_calendar_export_ics_file)
+	
+	if os.path.exists(file_name):
+		with open(file_name, 'r') as file:
+			file_content = file.read()
+		return file_content
+	else:
+		frappe.throw(f"File '{file_name}' not found.")


### PR DESCRIPTION
Issue:
The ICS only contains the word "undefined" after the download.

![Kazam_screencast_00133](https://github.com/phamos-eu/HR-Addon/assets/6966715/784017ca-bc0b-4edb-836a-c90f8f33d876)
