### PR TITLE
Put "cancelled" on the summary and not on UID

### DIFF
--- a/hr_addon/hr_addon/api/export_calendar.py
+++ b/hr_addon/hr_addon/api/export_calendar.py
@@ -26,7 +26,10 @@ def generate_leave_ical_file(leave_applications):
 
         event.add('dtstart', start_date)
         event.add('dtend', end_date)
-        event.add('summary', f'{employee_name} - {leave_type}')
+        summary = ""
+        if leave_application.get("cancelled"):
+            summary = "CANCELLED - "
+        event.add('summary', f'{summary}{employee_name} - {leave_type}')
         event.add('description', description)
         event.add("uid", uid)
 
@@ -49,10 +52,11 @@ def export_calendar(doc, method=None):
         index = 0
         for la in leave_applications:
             if la["status"] == "Cancelled":
+                la["cancelled"] = False
                 if la["name"] in [app["amended_from"] for app in leave_applications]:
                     del leave_applications[index]
                 else:
-                    la["name"] = "CANCELLED-{}".format(la["name"])
+                    la["cancelled"] = True
             index = index + 1
 
         ical_data = generate_leave_ical_file(leave_applications)


### PR DESCRIPTION
Issue: The UID is added with the prefix Cancelled and not the description of the appointment.

Expected result: 
![imagen](https://github.com/phamos-eu/HR-Addon/assets/6966715/8c6151c3-1431-4251-9134-1049c69e5464)

Actual result:
![Captura de pantalla de 2023-10-24 15-02-12](https://github.com/phamos-eu/HR-Addon/assets/6966715/00ef0f3a-9831-4c9d-8f03-91f763ff57c2)
