### PR TITLE
Generating workdays with scheduled job

### DIFF
--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -195,3 +195,9 @@ doc_events = {
 		"on_cancel": "hr_addon.hr_addon.api.export_calendar.export_calendar"
     }
 }
+
+scheduler_events = {
+	"hourly": [
+		"hr_addon.hr_addon.doctype.hr_addon_settings.hr_addon_settings.generate_workdays_scheduled_job"
+	],
+}

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -30,6 +30,14 @@ frappe.ui.form.on('HR Addon Settings', {
 				link.click();
 			}
 		});
+	},
+
+	generate_workdays_for_past_7_days_now: function(frm){
+		frappe.call({
+			method: "hr_addon.hr_addon.doctype.hr_addon_settings.hr_addon_settings.generate_workdays_for_past_7_days_now",
+		}).then(r => {
+			frappe.msgprint("The workdays have been generated.")
+		})
 	}
 });
 

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -15,7 +15,8 @@
   "scheduled_job_section",
   "day",
   "time",
-  "generate_workdays_for_past_7_days_now"
+  "generate_workdays_for_past_7_days_now",
+  "enabled"
  ],
  "fields": [
   {
@@ -76,12 +77,18 @@
    "fieldtype": "Select",
    "label": "Time",
    "options": "00\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23"
+  },
+  {
+   "default": "1",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-06 11:26:52.759748",
+ "modified": "2023-11-06 14:54:14.228938",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -11,7 +11,11 @@
   "allow_bulk_processing",
   "name_of_calendar_export_ics_file",
   "ics_folder_path",
-  "download_ics_file"
+  "download_ics_file",
+  "scheduled_job_section",
+  "day",
+  "time",
+  "generate_workdays_for_past_7_days_now"
  ],
  "fields": [
   {
@@ -47,12 +51,37 @@
    "fieldname": "download_ics_file",
    "fieldtype": "Button",
    "label": "Download ICS File"
+  },
+  {
+   "fieldname": "scheduled_job_section",
+   "fieldtype": "Section Break",
+   "label": "Scheduled Job"
+  },
+  {
+   "description": "It will be generated for every Employee",
+   "fieldname": "generate_workdays_for_past_7_days_now",
+   "fieldtype": "Button",
+   "label": "Generate Workdays for past 7 days now"
+  },
+  {
+   "default": "Sunday",
+   "fieldname": "day",
+   "fieldtype": "Select",
+   "label": "Day",
+   "options": "Sunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday"
+  },
+  {
+   "default": "00",
+   "fieldname": "time",
+   "fieldtype": "Select",
+   "label": "Time",
+   "options": "00\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-23 11:13:01.642208",
+ "modified": "2023-11-06 11:26:52.759748",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -4,6 +4,8 @@
 import frappe, os
 from frappe.model.document import Document
 
+from hr_addon.hr_addon.doctype.workday.workday import get_unmarked_range, process_bulk_workday
+
 class HRAddonSettings(Document):
 	def before_save(self):
 		# remove the old ics file
@@ -33,3 +35,38 @@ def download_ics_file():
 		return file_content
 	else:
 		frappe.throw(f"File '{file_name}' not found.")
+
+def generate_workdays_scheduled_job():
+	hr_addon_settings = frappe.get_doc("HR Addon Settings")
+	day = hr_addon_settings.day
+	time = hr_addon_settings.time
+	number2name_dict= {
+		0:"Monday",
+		1:"Tuesday",
+		2:"Wednesday",
+		3:"Thursday",
+		4:"Friday",
+		5:"Saturday",
+		6:"Sunday"
+	}
+	now = frappe.utils.datetime.datetime.now()
+	today_weekday_number = now.weekday()
+	weekday_name = number2name_dict[today_weekday_number]
+	if weekday_name == day:
+		if now.hour == int(time):
+			generate_workdays_for_past_7_days_now()
+
+
+@frappe.whitelist()
+def generate_workdays_for_past_7_days_now():
+	today = frappe.utils.datetime.datetime.now()
+	a_week_ago = today - frappe.utils.datetime.timedelta(days=7)
+	employees = frappe.db.get_list("Employee")
+	for employee in employees:
+		employee_name = employee["name"]
+		unmarked_days = get_unmarked_range(employee_name, a_week_ago.strftime("%Y-%m-%d"), today.strftime("%Y-%m-%d"))
+		data = {
+			"employee": employee_name,
+			"unmarked_days": unmarked_days
+		}
+		process_bulk_workday(data)

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -38,6 +38,8 @@ def download_ics_file():
 
 def generate_workdays_scheduled_job():
 	hr_addon_settings = frappe.get_doc("HR Addon Settings")
+	if hr_addon_settings.enabled == 0:
+		return
 	day = hr_addon_settings.day
 	time = hr_addon_settings.time
 	number2name_dict= {


### PR DESCRIPTION
What is included:
- [x] Add the following to the HR Addon Settings: day and time for the scheduled job to run, enable/disable checkbox, "Generate Workdays for past 7 days now" button
![Captura de pantalla de 2023-11-06 15-04-17](https://github.com/phamos-eu/HR-Addon/assets/6966715/c98f8fc0-8ceb-4844-af66-ec25b76f9fc7)

- [x] write the function to create the Workdays for all employees for the last 7 days
- [x] add the cron job for be run at the time specified in the settings (the cron job could be running every hour and checking if the current time is the same as the settings')..

![simplescreenrecorder-2023-11-06_14 42 14](https://github.com/phamos-eu/HR-Addon/assets/6966715/47420ec2-12f9-4f77-88f9-9304ce09c0c8)


