### PR TITLE
Reminder for Work Anniversaries

### DIFF
--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -109,24 +109,11 @@ doctype_js = {
 # Scheduled Tasks
 # ---------------
 
-# scheduler_events = {
-# 	"all": [
-# 		"hr_addon.tasks.all"
-# 	],
-# 	"daily": [
-# 		"hr_addon.tasks.daily"
-# 	],
-# 	"hourly": [
-# 		"hr_addon.tasks.hourly"
-# 	],
-# 	"weekly": [
-# 		"hr_addon.tasks.weekly"
-# 	]
-# 	"monthly": [
-# 		"hr_addon.tasks.monthly"
-# 	]
-# }
-
+scheduler_events = {
+	"daily": [
+		"hr_addon.hr_addon.api.utils.send_work_anniversary_notification"
+	]
+}
 # Testing
 # -------
 

--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -31,6 +31,9 @@ app_license = "MIT"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
+doctype_js = {
+    "HR Settings" : "public/js/hr_settings.js"
+}
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -186,5 +186,3 @@ user_data_fields = [
 # Recommended only for DocTypes which have limited documents with untranslated names
 # For example: Role, Gender, etc.
 # translated_search_doctypes = []
-
-# required_apps = ["hrms"]

--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -187,4 +187,4 @@ user_data_fields = [
 # For example: Role, Gender, etc.
 # translated_search_doctypes = []
 
-required_apps = ["hrms"]
+# required_apps = ["hrms"]

--- a/hr_addon/hr_addon/doctype/anniversary_email_list/anniversary_email_list.json
+++ b/hr_addon/hr_addon/doctype/anniversary_email_list/anniversary_email_list.json
@@ -1,0 +1,31 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-03-20 08:46:05.159202",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "employee"
+ ],
+ "fields": [
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-03-22 13:42:51.481105",
+ "modified_by": "Administrator",
+ "module": "HR Addon",
+ "name": "Anniversary Email List",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/hr_addon/hr_addon/doctype/anniversary_email_list/anniversary_email_list.py
+++ b/hr_addon/hr_addon/doctype/anniversary_email_list/anniversary_email_list.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, Jide Olayinka and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class AnniversaryEmailList(Document):
+	pass

--- a/hr_addon/hr_addon/doctype/employee_item/employee_item.json
+++ b/hr_addon/hr_addon/doctype/employee_item/employee_item.json
@@ -23,7 +23,7 @@
  "modified": "2024-03-22 13:42:51.481105",
  "modified_by": "Administrator",
  "module": "HR Addon",
- "name": "Anniversary Email List",
+ "name": "Employee Item",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",

--- a/hr_addon/hr_addon/doctype/employee_item/employee_item.py
+++ b/hr_addon/hr_addon/doctype/employee_item/employee_item.py
@@ -4,5 +4,5 @@
 # import frappe
 from frappe.model.document import Document
 
-class AnniversaryEmailList(Document):
+class EmployeeItem(Document):
 	pass

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -8,7 +8,9 @@
  "field_order": [
   "general_section",
   "runapp",
-  "allow_bulk_processing"
+  "allow_bulk_processing",
+  "send_work_anniversary_reminders",
+  "anniversary_notification_email_list"
  ],
  "fields": [
   {
@@ -27,12 +29,24 @@
    "fieldname": "allow_bulk_processing",
    "fieldtype": "Check",
    "label": "Allow Bulk Processing"
+  },
+  {
+   "default": "0",
+   "fieldname": "send_work_anniversary_reminders",
+   "fieldtype": "Check",
+   "label": "Work Anniversaries "
+  },
+  {
+   "fieldname": "anniversary_notification_email_list",
+   "fieldtype": "Table MultiSelect",
+   "label": "Anniversary Notification Email List",
+   "options": "Employee Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-05-13 22:53:32.840880",
+ "modified": "2024-03-22 14:06:24.144498",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -9,7 +9,7 @@
   "general_section",
   "runapp",
   "allow_bulk_processing",
-  "send_work_anniversary_reminders",
+  "send_work_anniversary_notifications",
   "anniversary_notification_email_list"
  ],
  "fields": [
@@ -31,22 +31,24 @@
    "label": "Allow Bulk Processing"
   },
   {
-   "default": "0",
-   "fieldname": "send_work_anniversary_reminders",
-   "fieldtype": "Check",
-   "label": "Work Anniversaries "
-  },
-  {
+   "depends_on": "eval: doc.send_work_anniversary_notifications",
    "fieldname": "anniversary_notification_email_list",
    "fieldtype": "Table MultiSelect",
    "label": "Anniversary Notification Email List",
+   "mandatory_depends_on": "eval: doc.send_work_anniversary_notifications",
    "options": "Employee Item"
+  },
+  {
+   "default": "0",
+   "fieldname": "send_work_anniversary_notifications",
+   "fieldtype": "Check",
+   "label": "Work Anniversaries "
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-22 14:06:24.144498",
+ "modified": "2024-03-25 10:28:56.947190",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/public/js/hr_settings.js
+++ b/hr_addon/public/js/hr_settings.js
@@ -1,0 +1,12 @@
+
+frappe.ui.form.on("HR Settings", {
+	refresh: (frm) => {
+		if(!frm.is_new()) {
+			frm.dashboard.set_headline_alert(`
+				<span class="hidden-xs">There's some additional configuration for 'Work Anniversaries' which you'll find in <a style="text-decoration: underline;" onclick="frappe.set_route('Form', 'HR Addon Settings', 'HR Addon Settings');">HR Addon Settings</a></span>
+			`);
+		}
+
+		frm.set_df_property("send_work_anniversary_reminders", "description", "There's some additional configuration for this notification in 'HR Addon Settings' please check.");
+	}
+})


### PR DESCRIPTION
https://kanban.phamos.eu/b/GKyrHiDRmKaDFtFj6/suncycle/2CinfQLaifkM3RoXH

1. Settings to configure in HR Addon Settings for sending anniversary notification to selected Employees. Work Anniversaries (1) should be checked, and all Employees who want receive email must be set in (2)  
![image](https://github.com/phamos-eu/HR-Addon/assets/25414115/946056e0-a06d-4fe2-82e1-ba227bac57ba)


3. Indication (1 and 2) in HR Settings for Installation of HR-Addon app and relevant settings enhancement  
![image](https://github.com/phamos-eu/HR-Addon/assets/25414115/067a4c42-2b46-45d4-8d95-fd80020645a1)
