### PR TITLE
Work Anniversary Reminder

### DIFF
--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -30,8 +30,9 @@ app_license = "MIT"
 # include js in page
 # page_js = {"page" : "public/js/file.js"}
 doctype_js = {
-   
+    "HR Settings" : "public/js/hr_settings.js"
 }
+
 # include js in doctype views
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}

--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -108,7 +108,11 @@ doctype_js = {
 
 # Scheduled Tasks
 # ---------------
-
+scheduler_events = {
+	"daily": [
+		"hr_addon.hr_addon.api.utils.send_work_anniversary_notification"
+	]
+}
 # scheduler_events = {
 # 	"all": [
 # 		"hr_addon.tasks.all"

--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -211,7 +211,7 @@ def date_is_in_holiday_list(employee, date):
 # ----------------------------------------------------------------------
 def send_work_anniversary_notification():
     """Send Employee Work Anniversary Reminders if 'Send Work Anniversary Reminders' is checked"""
-    if not int(frappe.db.get_single_value("HR Addon Settings", "enable_work_anniversary_notifications")):
+    if not int(frappe.db.get_single_value("HR Addon Settings", "enable_work_anniversaries_notification")):
         return
     
     ############## Sending email to specified employees in HR Addon Settings field anniversary_notification_email_list
@@ -251,8 +251,8 @@ def send_work_anniversary_notification():
         if role_email_recipients:
             send_emails(employees_joined_seven_days_later, role_email_recipients, joining_date)
 
-    ############## Sending email to specified employee leave approvers if HR Addon Settings field enable_work_anniversaries_for_leave_approver is checked
-    if int(frappe.db.get_single_value("HR Addon Settings", "enable_work_anniversaries_for_leave_approver")):
+    ############## Sending email to specified employee leave approvers if HR Addon Settings field enable_work_anniversaries_notification_for_leave_approvers is checked
+    if int(frappe.db.get_single_value("HR Addon Settings", "enable_work_anniversaries_notification_for_leave_approvers")):
         for company, anniversary_persons in employees_joined_seven_days_later.items():
             for anniversary_person in anniversary_persons:
                 if anniversary_person.get("leave_approver"):

--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -4,7 +4,9 @@ import frappe
 from frappe import _
 
 from frappe.utils.data import date_diff, time_diff_in_seconds
-from frappe.utils import cint, cstr, formatdate, get_datetime, getdate, nowdate
+from frappe.utils import get_datetime, getdate, today, comma_sep
+from frappe.core.doctype.role.role import get_info_based_on_role
+
 
 #@frappe.whitelist()
 def get_employee_checkin(employee,atime):
@@ -203,3 +205,167 @@ def date_is_in_holiday_list(employee, date):
 			return True
 
 	return False
+
+# ----------------------------------------------------------------------
+# WORK ANNIVERSARY REMINDERS SEND TO EMPLOYEES LIST IN HR-ADDON-SETTINGS
+# ----------------------------------------------------------------------
+def send_work_anniversary_notification():
+    """Send Employee Work Anniversary Reminders if 'Send Work Anniversary Reminders' is checked"""
+    if not int(frappe.db.get_single_value("HR Addon Settings", "enable_work_anniversary_notifications")):
+        return
+    
+    ############## Sending email to specified employees in HR Addon Settings field anniversary_notification_email_list
+    emp_email_list = frappe.db.get_all("Employee Item", {"parent": "HR Addon Settings", "parentfield": "anniversary_notification_email_list"}, "employee")
+    recipients = []
+    for employee in emp_email_list:
+        employee_doc = frappe.get_doc("Employee", employee)
+        employee_email = employee_doc.get("user_id") or employee_doc.get("personal_email") or employee_doc.get("company_email")
+        if employee_email:
+            recipients.append({"employee_email": employee_email, "company": employee_doc.company})
+        else:
+            frappe.throw(_("Email not set for {0}".format(employee)))
+
+    if not recipients:
+        frappe.throw(_("Recipient Employees not set in field 'Anniversary Notification Email List'"))
+
+    joining_date = today()
+    employees_joined_today = get_employees_having_an_event_on_given_date("work_anniversary", joining_date)
+    send_emails(employees_joined_today, recipients, joining_date)
+
+    ############## Sending email to specified employees with Role in HR Addon Settings field anniversary_notification_email_recipient_role
+    email_recipient_role = frappe.db.get_single_value("HR Addon Settings", "anniversary_notification_email_recipient_role")
+    joining_date = frappe.utils.add_days(today(), 7)
+    employees_joined_seven_days_later = get_employees_having_an_event_on_given_date("work_anniversary", joining_date)
+    if email_recipient_role:
+        role_email_recipients = []
+        users_with_role = get_info_based_on_role(email_recipient_role, field="email")
+        for user in users_with_role:
+            emp_data = frappe.get_cached_value("Employee", {"user_id": user}, ["company", "user_id"], as_dict=True)
+            if emp_data:
+                role_email_recipients.extend([{"employee_email": emp_data.get("user_id"), "company": emp_data.get("company")}])
+            else:
+                # leave approver not set
+                pass
+                # frappe.msgprint(cstr(anniversary_person))
+
+        if role_email_recipients:
+            send_emails(employees_joined_seven_days_later, role_email_recipients, joining_date)
+
+    ############## Sending email to specified employee leave approvers if HR Addon Settings field enable_work_anniversaries_for_leave_approver is checked
+    if int(frappe.db.get_single_value("HR Addon Settings", "enable_work_anniversaries_for_leave_approver")):
+        for company, anniversary_persons in employees_joined_seven_days_later.items():
+            for anniversary_person in anniversary_persons:
+                if anniversary_person.get("leave_approver"):
+                    leave_approver_recipients = [anniversary_person.get("leave_approver")]
+                    
+                    reminder_text, message = get_work_anniversary_reminder_text_and_message(anniversary_persons, joining_date)
+                    send_work_anniversary_reminder(leave_approver_recipients, reminder_text, anniversary_persons, message)
+
+                else:
+                    # leave approver not set
+                    pass
+                    # frappe.msgprint(cstr(anniversary_person))
+
+
+def send_emails(employees_joined_today, recipients, joining_date):
+
+    for company, anniversary_persons in employees_joined_today.items():
+        reminder_text, message = get_work_anniversary_reminder_text_and_message(anniversary_persons, joining_date)
+        recipients_by_company = [d.get('employee_email') for d in recipients if d.get('company') == company ]
+        if recipients_by_company:
+            send_work_anniversary_reminder(recipients_by_company, reminder_text, anniversary_persons, message)
+
+
+def get_employees_having_an_event_on_given_date(event_type, date):
+    """Get all employee who have `event_type` on specific_date
+    & group them based on their company. `event_type`
+    can be `birthday` or `work_anniversary`"""
+
+    from collections import defaultdict
+
+    # Set column based on event type
+    if event_type == "birthday":
+        condition_column = "date_of_birth"
+    elif event_type == "work_anniversary":
+        condition_column = "date_of_joining"
+    else:
+        return
+
+    employees_born_on_given_date = frappe.db.sql("""
+            SELECT `personal_email`, `company`, `company_email`, `user_id`, `employee_name` AS 'name', `leave_approver`, `image`, `date_of_joining`
+            FROM `tabEmployee`
+            WHERE
+                DAY({0}) = DAY(%(date)s)
+            AND
+                MONTH({0}) = MONTH(%(date)s)
+            AND
+                YEAR({0}) < YEAR(%(date)s)
+            AND
+                `status` = 'Active'
+        """.format(condition_column), {"date": date}, as_dict=1
+    )
+    grouped_employees = defaultdict(lambda: [])
+
+    for employee_doc in employees_born_on_given_date:
+        grouped_employees[employee_doc.get("company")].append(employee_doc)
+
+    return grouped_employees
+
+
+def get_work_anniversary_reminder_text_and_message(anniversary_persons, joining_date):
+    today_date = today()
+    if joining_date == today_date:
+        days_alias = "Today"
+        completed = "completed"
+
+    elif joining_date > today_date:
+        days_alias = "{0} days later".format(date_diff(joining_date, today_date))
+        completed = "will complete"
+
+    if len(anniversary_persons) == 1:
+        anniversary_person = anniversary_persons[0]["name"]
+        persons_name = anniversary_person
+        # Number of years completed at the company
+        completed_years = getdate().year - anniversary_persons[0]["date_of_joining"].year
+        anniversary_person += f" {completed} {get_pluralized_years(completed_years)}"
+    else:
+        person_names_with_years = []
+        names = []
+        for person in anniversary_persons:
+            person_text = person["name"]
+            names.append(person_text)
+            # Number of years completed at the company
+            completed_years = getdate().year - person["date_of_joining"].year
+            person_text += f" {completed} {get_pluralized_years(completed_years)}"
+            person_names_with_years.append(person_text)
+
+        # converts ["Jim", "Rim", "Dim"] to Jim, Rim & Dim
+        anniversary_person = comma_sep(person_names_with_years, frappe._("{0} & {1}"), False)
+        persons_name = comma_sep(names, frappe._("{0} & {1}"), False)
+
+    reminder_text = _("{0} {1} at our Company! 🎉").format(days_alias, anniversary_person)
+    message = _("A friendly reminder of an important date for our team.")
+    message += "<br>"
+    message += _("Everyone, let’s congratulate {0} on their work anniversary!").format(persons_name)
+
+    return reminder_text, message
+
+
+def send_work_anniversary_reminder(recipients, reminder_text, anniversary_persons, message):
+    frappe.sendmail(
+        recipients=recipients,
+        subject=_("Work Anniversary Reminder"),
+        template="anniversary_reminder",
+        args=dict(
+            reminder_text=reminder_text,
+            anniversary_persons=anniversary_persons,
+            message=message,
+        ),
+        header=_("Work Anniversary Reminder"),
+    )
+
+
+def get_pluralized_years(years):
+    if years == 1:
+        return "1 year"
+    return f"{years} years"

--- a/hr_addon/hr_addon/doctype/employee_item/employee_item.json
+++ b/hr_addon/hr_addon/doctype/employee_item/employee_item.json
@@ -1,0 +1,36 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-05-31 11:01:34.865180",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_m5my",
+  "employee"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_m5my",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "employee",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Employee",
+   "options": "Employee"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-05-31 11:02:40.853991",
+ "modified_by": "Administrator",
+ "module": "HR Addon",
+ "name": "Employee Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hr_addon/hr_addon/doctype/employee_item/employee_item.py
+++ b/hr_addon/hr_addon/doctype/employee_item/employee_item.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Jide Olayinka and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EmployeeItem(Document):
+	pass

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -2,22 +2,36 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('HR Addon Settings', {
-	// refresh: function(frm) {
-
-	// }
-
-	validate: function(frm){
-		if (frm.doc.name_of_calendar_export_ics_file.length == 0){
-			const randomString = generateRandomString(24);
-			frm.set_value("name_of_calendar_export_ics_file", randomString)
-		}
+	refresh: function(frm) {
+        frm.add_custom_button(
+            __("Test"),
+            function () {
+                frappe.call({
+                    method: "hr_addon.hr_addon.api.utils.send_work_anniversary_notification",
+                    args: {
+                        doc: frm.doc,
+                    },
+                    freeze: true,
+                    callback: function (r) {
+                        
+                    },
+                });
+            },
+        );
 	},
 
-	after_save: function(frm){
-		if (frm.doc.name_of_calendar_export_ics_file.length < 24){
-			frappe.msgprint("The filename is less than 24 characters. Please, consider to have a longer filename or leave it empty to get a random filename.")
-		}
-	},
+	// validate: function(frm){
+	// 	if (frm.doc.name_of_calendar_export_ics_file.length == 0){
+	// 		const randomString = generateRandomString(24);
+	// 		frm.set_value("name_of_calendar_export_ics_file", randomString)
+	// 	}
+	// },
+
+	// after_save: function(frm){
+	// 	if (frm.doc.name_of_calendar_export_ics_file.length < 24){
+	// 		frappe.msgprint("The filename is less than 24 characters. Please, consider to have a longer filename or leave it empty to get a random filename.")
+	// 	}
+	// },
 
 	download_ics_file: function(frm){
 		frappe.call({

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -3,35 +3,20 @@
 
 frappe.ui.form.on('HR Addon Settings', {
 	refresh: function(frm) {
-        frm.add_custom_button(
-            __("Test"),
-            function () {
-                frappe.call({
-                    method: "hr_addon.hr_addon.api.utils.send_work_anniversary_notification",
-                    args: {
-                        doc: frm.doc,
-                    },
-                    freeze: true,
-                    callback: function (r) {
-                        
-                    },
-                });
-            },
-        );
 	},
 
-	// validate: function(frm){
-	// 	if (frm.doc.name_of_calendar_export_ics_file.length == 0){
-	// 		const randomString = generateRandomString(24);
-	// 		frm.set_value("name_of_calendar_export_ics_file", randomString)
-	// 	}
-	// },
+	validate: function(frm){
+		if (frm.doc.name_of_calendar_export_ics_file.length == 0){
+			const randomString = generateRandomString(24);
+			frm.set_value("name_of_calendar_export_ics_file", randomString)
+		}
+	},
 
-	// after_save: function(frm){
-	// 	if (frm.doc.name_of_calendar_export_ics_file.length < 24){
-	// 		frappe.msgprint("The filename is less than 24 characters. Please, consider to have a longer filename or leave it empty to get a random filename.")
-	// 	}
-	// },
+	after_save: function(frm){
+		if (frm.doc.name_of_calendar_export_ics_file.length < 24){
+			frappe.msgprint("The filename is less than 24 characters. Please, consider to have a longer filename or leave it empty to get a random filename.")
+		}
+	},
 
 	download_ics_file: function(frm){
 		frappe.call({

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -98,11 +98,11 @@
    "label": "Anniversary Notification"
   },
   {
-   "depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "depends_on": "eval: doc.enable_work_anniversaries_notification",
    "fieldname": "anniversary_notification_email_list",
    "fieldtype": "Table MultiSelect",
    "label": "Anniversary Notification Email List",
-   "mandatory_depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "mandatory_depends_on": "eval: doc.enable_work_anniversaries_notification",
    "options": "Employee Item"
   },
   {
@@ -110,7 +110,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "depends_on": "eval: doc.enable_work_anniversaries_notification",
    "fieldname": "anniversary_notification_email_recipient_role",
    "fieldtype": "Link",
    "label": "Anniversary Notification Email Recipient Role",
@@ -134,7 +134,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-05 13:44:06.876268",
+ "modified": "2024-06-05 13:48:08.302927",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -122,7 +122,7 @@
    "fieldname": "enable_work_anniversaries_notification_for_leave_approvers",
    "fieldtype": "Check",
    "label": "Enable Work Anniversaries notification for Leave Approvers",
-   "mandatory_depends_on": "eval: doc.enable_work_anniversary_notifications"
+   "mandatory_depends_on": "eval: doc.enable_work_anniversaries_notification"
   },
   {
    "default": "0",
@@ -134,7 +134,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-05 13:48:08.302927",
+ "modified": "2024-06-05 13:57:48.550208",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -16,7 +16,13 @@
   "day",
   "time",
   "generate_workdays_for_past_7_days_now",
-  "enabled"
+  "enabled",
+  "notification_section",
+  "anniversary_notification_email_list",
+  "enable_work_anniversary_notifications",
+  "enable_work_anniversaries_for_leave_approver",
+  "column_break_dvlg",
+  "anniversary_notification_email_recipient_role"
  ],
  "fields": [
   {
@@ -84,12 +90,51 @@
    "fieldname": "enabled",
    "fieldtype": "Check",
    "label": "Enabled"
+  },
+  {
+   "fieldname": "notification_section",
+   "fieldtype": "Section Break",
+   "label": "Anniversary Notification"
+  },
+  {
+   "depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "fieldname": "anniversary_notification_email_list",
+   "fieldtype": "Table MultiSelect",
+   "label": "Anniversary Notification Email List",
+   "mandatory_depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "options": "Employee Item"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_work_anniversary_notifications",
+   "fieldtype": "Check",
+   "label": "Enable Work Anniversaries"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "fieldname": "enable_work_anniversaries_for_leave_approver",
+   "fieldtype": "Check",
+   "label": "Enable Work Anniversaries for Leave Approver",
+   "mandatory_depends_on": "eval: doc.enable_work_anniversary_notifications"
+  },
+  {
+   "fieldname": "column_break_dvlg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "fieldname": "anniversary_notification_email_recipient_role",
+   "fieldtype": "Link",
+   "label": "Anniversary Notification Email Recipient Role",
+   "mandatory_depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "options": "Role"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-10 13:50:23.399969",
+ "modified": "2024-05-31 15:12:23.095650",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",
@@ -118,5 +163,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -1,4 +1,5 @@
 {
+ "_comments": "[{\"comment\": \"<div class=\\\"ql-editor read-mode\\\"><p>Enable Work Anniversaries notification for Leave Approver</p>...\", \"by\": \"Administrator\", \"name\": \"64bk4h7mnd\"}, {\"comment\": \"<div class=\\\"ql-editor read-mode\\\"><p>Enable Work Anniversaries notification</p></div>\", \"by\": \"Administrator\", \"name\": \"64t9m5fb37\"}]",
  "actions": [],
  "allow_rename": 1,
  "creation": "2022-05-13 22:53:32.840880",
@@ -19,8 +20,8 @@
   "enabled",
   "notification_section",
   "anniversary_notification_email_list",
-  "enable_work_anniversary_notifications",
-  "enable_work_anniversaries_for_leave_approver",
+  "enable_work_anniversaries_notification",
+  "enable_work_anniversaries_notification_for_leave_approvers",
   "column_break_dvlg",
   "anniversary_notification_email_recipient_role"
  ],
@@ -105,20 +106,6 @@
    "options": "Employee Item"
   },
   {
-   "default": "0",
-   "fieldname": "enable_work_anniversary_notifications",
-   "fieldtype": "Check",
-   "label": "Enable Work Anniversaries"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.enable_work_anniversary_notifications",
-   "fieldname": "enable_work_anniversaries_for_leave_approver",
-   "fieldtype": "Check",
-   "label": "Enable Work Anniversaries for Leave Approver",
-   "mandatory_depends_on": "eval: doc.enable_work_anniversary_notifications"
-  },
-  {
    "fieldname": "column_break_dvlg",
    "fieldtype": "Column Break"
   },
@@ -127,14 +114,27 @@
    "fieldname": "anniversary_notification_email_recipient_role",
    "fieldtype": "Link",
    "label": "Anniversary Notification Email Recipient Role",
-   "mandatory_depends_on": "eval: doc.enable_work_anniversary_notifications",
    "options": "Role"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.enable_work_anniversary_notifications",
+   "fieldname": "enable_work_anniversaries_notification_for_leave_approvers",
+   "fieldtype": "Check",
+   "label": "Enable Work Anniversaries notification for Leave Approvers",
+   "mandatory_depends_on": "eval: doc.enable_work_anniversary_notifications"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_work_anniversaries_notification",
+   "fieldtype": "Check",
+   "label": "Enable Work Anniversaries notification"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-05-31 15:12:23.095650",
+ "modified": "2024-06-05 13:44:06.876268",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/public/js/hr_settings.js
+++ b/hr_addon/public/js/hr_settings.js
@@ -1,0 +1,11 @@
+frappe.ui.form.on("HR Settings", {
+	refresh: (frm) => {
+		if(!frm.is_new()) {
+			frm.dashboard.set_headline_alert(`
+				<span class="hidden-xs">There's some additional configuration for 'Work Anniversaries' which you'll find in <a style="text-decoration: underline;" onclick="frappe.set_route('Form', 'HR Addon Settings', 'HR Addon Settings');">HR Addon Settings</a></span>
+			`);
+		}
+
+		frm.set_df_property("send_work_anniversary_reminders", "description", "There's some additional configuration for this notification in 'HR Addon Settings' please check.");
+	}
+})


### PR DESCRIPTION
1. Sending email to specified employees in HR Addon Settings field anniversary_notification_email_list
2. Sending email to specified employees with Role in HR Addon Settings field anniversary_notification_email_recipient_role
3. Sending email to specified employee leave approvers if HR Addon Settings field enable_work_anniversaries_for_leave_approver is checked