### PR TITLE
feat:add validation on duplication employee checkin

### DIFF
--- a/hr_addon/custom_scripts/custom_python/employee_checkin.py
+++ b/hr_addon/custom_scripts/custom_python/employee_checkin.py
@@ -1,0 +1,28 @@
+import qrcode
+import frappe
+from frappe.utils import get_url_to_form
+from frappe import _
+
+@frappe.whitelist()
+def validate_duplicate_log(doc, method):
+		# Custom SQL query to check existence without using doc.time.date()
+    data = frappe.db.sql(
+        """
+        SELECT
+            name as ec
+        FROM `tabEmployee Checkin`
+        WHERE
+            DATE(time) = DATE(%s)
+            AND employee = %s
+            AND name != %s
+            AND log_type = %s
+        """,
+        (doc.time, doc.employee, doc.name, doc.log_type),
+        as_dict=True
+    )
+    
+    # Check if any record was found
+    if data and data[0].get('ec'):
+        text = "This employee already has a log with the same timestamp" + "</br>"+data[0].get('ec')
+        frappe.throw( text)
+

--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -201,7 +201,10 @@ doc_events = {
     },
     "Location": {
         "after_insert": "hr_addon.custom_scripts.custom_python.location.generate_qr_code_for_location",
-    }
+    },
+    "Employee Checkin": {
+        "validate": "hr_addon.custom_scripts.custom_python.employee_checkin.validate_duplicate_log",
+    },
 }
 
 scheduler_events = {

--- a/hr_addon/patches.txt
+++ b/hr_addon/patches.txt
@@ -1,3 +1,3 @@
 hr_addon.patches.v15_0.add_custom_field_for_employee
 hr_addon.patches.v15_0.add_custom_field_for_hr_settings #12
-hr_addon.patches.v15_0.add_custom_field_for_location #1
+hr_addon.patches.v15_0.add_custom_field_for_location #123

--- a/hr_addon/patches/v15_0/add_custom_field_for_location.py
+++ b/hr_addon/patches/v15_0/add_custom_field_for_location.py
@@ -5,9 +5,15 @@ from frappe.custom.doctype.property_setter.property_setter import make_property_
 def execute():
     
     frappe.reload_doc("Assets", "doctype", "Location")
+    frappe.reload_doc("HR", "doctype", "employee_checkin")
+
 
     create_custom_field("Location",
 		dict(fieldname="qr_code_url", label="QR Code URL",
 			fieldtype="Data", insert_after="location",read_only=1
 		)
 	)
+	
+    make_property_setter("Employee Checkin", "device_id", "depends_on",
+			'eval:frappe.user.has_role("HR User") || frappe.user.has_role("HR Manager")',
+			"Data")


### PR DESCRIPTION
1. "Validation has been added to prevent duplication of employee check-ins for both IN and OUT statuses."

<img width="1230" alt="Screenshot 2024-06-29 at 21 46 14" src="https://github.com/phamos-eu/HR-Addon/assets/61533913/3f9dc654-701b-40e6-b289-47d132ded103">

2. Depends On condition added - Device Id field will be visible to HR User and HR Manager.

