### PR TITLE
feat:add df_property hidden on device_id in employee checkin

### DIFF
--- a/hr_addon/patches.txt
+++ b/hr_addon/patches.txt
@@ -1,3 +1,3 @@
 hr_addon.patches.v15_0.add_custom_field_for_employee
 hr_addon.patches.v15_0.add_custom_field_for_hr_settings #12
-hr_addon.patches.v15_0.add_custom_field_for_location #123
+hr_addon.patches.v15_0.add_custom_field_for_location #1234

--- a/hr_addon/patches/v15_0/add_custom_field_for_location.py
+++ b/hr_addon/patches/v15_0/add_custom_field_for_location.py
@@ -14,6 +14,4 @@ def execute():
 		)
 	)
 	
-    make_property_setter("Employee Checkin", "device_id", "depends_on",
-			'eval:frappe.user.has_role("HR User") || frappe.user.has_role("HR Manager")',
-			"Data")
+    make_property_setter("Employee Checkin", "device_id", "depends_on",'',"Data")

--- a/hr_addon/public/js/employee_checkin.js
+++ b/hr_addon/public/js/employee_checkin.js
@@ -7,6 +7,10 @@ frappe.ui.form.on('Employee Checkin', {
                 }
             });
         }
+
+        const hasHRRole = frappe.user.has_role("HR User") || frappe.user.has_role("HR Manager");
+        if (!hasHRRole) {
+            frm.set_df_property('device_id', 'hidden', 1);
+        }
     }
- });
- 
+});


### PR DESCRIPTION
Development added on employee checkin.

IF the current user has either the "HR User" role or the "HR Manager" role by calling frappe.user.has_role("HR User") and frappe.user.has_role("HR Manager") then device_id will be visible.
