### PR TITLE
feat:validation added to prevent duplication of weekly working hours

### DIFF
--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
+from frappe import _, bold
 
 class WeeklyWorkingHours(Document):
 	#pass
@@ -15,4 +16,23 @@ class WeeklyWorkingHours(Document):
 		name_key = coy+'-.YYYY.-'+e_name+'-.####'
 		self.name = make_autoname(name_key)
 		self.title_hour= self.name
+
+	def validate(self):
+		self.validate_record()
+
+	def validate_record(self):
+		existing_record =  frappe.db.get_value("Weekly Working Hours",
+		{
+			"employee": self.employee,
+			"valid_from": self.valid_from,
+			"valid_to":self.valid_to,
+			"name": ("!=", self.name),
+			"docstatus":1
+		}, "name")
+		if existing_record :
+			frappe.throw(
+					_("Weekly Working Hours, already exists for this Employee {0}. Existing record : {1}").format(self.employee,existing_record)
+				)
+		
+
 

--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
@@ -25,28 +25,29 @@ class WeeklyWorkingHours(Document):
 	# and ensures no overlapping days within the same date range for a specific employee.
 	def validate_record(self):
 		# Check for overlapping date ranges
-		existing_record = frappe.db.sql("""
+		existing_records = frappe.db.sql("""
         SELECT wwh.name
         FROM `tabWeekly Working Hours` wwh
         WHERE
             wwh.employee = %s AND
             wwh.docstatus = 1 AND
             wwh.name != %s AND (
-                (wwh.valid_from <= %s AND wwh.valid_to >= %s) OR
-                (wwh.valid_from <= %s AND wwh.valid_to >= %s)
+                (wwh.valid_from <= %s AND wwh.valid_to >= %s) 
             )
-    """, (self.employee, self.name, self.valid_from, self.valid_to, self.valid_from, self.valid_to))
+    """, (self.employee, self.name, self.valid_from, self.valid_to))
+		print(existing_records)
 		# Check for overlapping days
-		if existing_record:
+		for existing_record in existing_records:
+			print(existing_record[0])
 			for day in self.hours:
 				existing_record_days = frappe.db.sql("""
                 SELECT dhd.day
                 FROM `tabDaily Hours Detail` dhd
                 WHERE dhd.parent = %s AND dhd.day = %s
-            """, (existing_record[0][0], day.get('day')))
+            """, (existing_record[0], day.get('day')))
 				if existing_record_days:
 					frappe.throw(
-                    _("Weekly Working Hours already exist for this Employee {0} with overlapping dates and days. </br> Existing Weekly Working Hours : {1}.").format(self.employee,existing_record[0][0])
+                    _("Weekly Working Hours already exist for this Employee {0} with overlapping dates and days. </br> Existing Weekly Working Hours : {1}.").format(self.employee,existing_record[0])
                 )
                 
        


### PR DESCRIPTION
[#149](https://git.phamos.eu/suncycle/suncycle/-/issues/149) Weekly Working Hours (General Issue in HR Addon)

https://chat.phamos.eu/phamos/pl/rwzifji3ej8m88wje16zy7dxfh

TODO: add validation for the Weekly Working Hour to have only one validated document for the same date range

Validation added - to check if there is already a "Weekly Working Hours" record for a specific employee within the given date range. 

Validates if a new record's date range overlaps with existing records,
and ensures no overlapping days within the same date range for a specific employee.


<img width="1228" alt="Screenshot 2024-07-04 at 11 45 03" src="https://github.com/phamos-eu/HR-Addon/assets/61533913/77cf58e5-94ac-4e26-bc14-cd1440228622">

