### PR TITLE
feat:if comp off on date update working hours to 0 in workday

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -55,17 +55,18 @@ def get_actual_employee_log(aemployee, adate):
 
     employee_default_work_hour = get_employee_default_work_hour(aemployee,adate)
     is_date_in_holiday_list = date_is_in_holiday_list(aemployee,adate)
+    is_date_in_comp_off = date_is_in_comp_off(aemployee,adate)
     fields=["name", "no_break_hours", "set_target_hours_to_zero_when_date_is_holiday"]
     weekly_working_hours = frappe.db.get_list(doctype="Weekly Working Hours", filters={"employee": aemployee}, fields=fields)
     no_break_hours = True if len(weekly_working_hours) > 0 and weekly_working_hours[0]["no_break_hours"] == 1 else False
     is_target_hours_zero_on_holiday = len(weekly_working_hours) > 0 and weekly_working_hours[0]["set_target_hours_to_zero_when_date_is_holiday"] == 1
     
-    new_workday = get_workday(employee_checkins, employee_default_work_hour, no_break_hours, is_target_hours_zero_on_holiday, is_date_in_holiday_list)
+    new_workday = get_workday(employee_checkins, employee_default_work_hour, no_break_hours, is_target_hours_zero_on_holiday, is_date_in_holiday_list,is_date_in_comp_off)
 
     return new_workday
 
 
-def get_workday(employee_checkins, employee_default_work_hour, no_break_hours, is_target_hours_zero_on_holiday, is_date_in_holiday_list=False):
+def get_workday(employee_checkins, employee_default_work_hour, no_break_hours, is_target_hours_zero_on_holiday, is_date_in_holiday_list=False,is_date_in_comp_off=False):
     new_workday = {}
 
     hours_worked = 0.0
@@ -118,6 +119,10 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours, i
     if is_target_hours_zero_on_holiday and is_date_in_holiday_list:
         target_hours = 0
         total_target_seconds = 0
+
+    if is_date_in_comp_off:
+        hours_worked = 0
+        actual_working_hours = 0    
 
     hr_addon_settings = frappe.get_doc("HR Addon Settings")
     if hr_addon_settings.enable_default_break_hour_for_shorter_breaks:
@@ -205,6 +210,22 @@ def date_is_in_holiday_list(employee, date):
     )
 
 	return len(holidays) > 0
+
+@frappe.whitelist()
+def date_is_in_comp_off(employee, date):
+    comp_off_leave_application = frappe.db.sql("""
+        SELECT name 
+        FROM `tabLeave Application` 
+        WHERE employee = %s 
+        AND %s BETWEEN from_date AND to_date 
+        AND leave_type = %s
+    """, (employee, date, 'Freizeitausgleich (Nicht buchen!)'))
+
+    if comp_off_leave_application:
+        return comp_off_leave_application[0][0]
+    else:
+        return None
+
 
 # ----------------------------------------------------------------------
 # WORK ANNIVERSARY REMINDERS SEND TO EMPLOYEES LIST IN HR-ADDON-SETTINGS

--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -3,18 +3,7 @@
 
 frappe.ui.form.on("Workday", {
   refresh: function (frm) {
-    if (frm.doc.break_hours == -360 && frm.doc.hours_worked == -36) {
-      $(".control-input-wrapper > .control-value.like-disabled-input").css(
-        "color",
-        "red"
-      );
-    } else {
-      // Reset the color to default (or any other color) when the condition is not met
-      $(".control-input-wrapper > .control-value.like-disabled-input").css(
-        "color",
-        ""
-      );
-    }
+    set_color_red(frm);
   },
   setup: function (frm) {
     frm.set_query("attendance", function () {
@@ -119,6 +108,7 @@ var get_hours = function (frm) {
               nw_checkins.log_time = e.time;
               nw_checkins.skip_auto_attendance = e.skip_auto_attendance;
               refresh_field("employee_checkins");
+              set_color_red(frm);
             });
           }
         } else {
@@ -141,4 +131,19 @@ var unset_fields = function (frm) {
   frm.set_value("first_checkin", "");
   frm.set_value("last_checkout", "");
   frm.refresh_fields();
+};
+
+var set_color_red = function (frm) {
+  if (frm.doc.break_hours == -360 && frm.doc.hours_worked == -36) {
+    $(".control-input-wrapper > .control-value.like-disabled-input").css(
+      "color",
+      "red"
+    );
+  } else {
+    // Reset the color to default (or any other color) when the condition is not met
+    $(".control-input-wrapper > .control-value.like-disabled-input").css(
+      "color",
+      ""
+    );
+  }
 };

--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -36,7 +36,14 @@ frappe.ui.form.on("Workday", {
   attendance: function (frm) {
     get_hours(frm);
   },
-
+  validate: function (frm) {
+    if (frm.doc.break_hours == -360 && frm.doc.hours_worked == -36) {
+      let formatted_date = frappe.datetime.str_to_user(frm.doc.log_date);
+      frappe.throw(
+        "CheckIns must be in pairs for the given date: " + formatted_date
+      );
+    }
+  },
   log_date: function (frm) {
     if (frm.doc.employee && frm.doc.log_date) {
       frappe.call({

--- a/hr_addon/hr_addon/doctype/workday/workday.json
+++ b/hr_addon/hr_addon/doctype/workday/workday.json
@@ -59,7 +59,8 @@
   {
    "fieldname": "target_hours",
    "fieldtype": "Float",
-   "label": "Target Hours"
+   "label": "Target Hours",
+   "read_only": 1
   },
   {
    "fieldname": "hours_worked",
@@ -71,14 +72,12 @@
   {
    "fieldname": "number_of_breaks",
    "fieldtype": "Int",
-   "hidden": 0,
    "label": "Number of Breaks",
    "read_only": 1
   },
   {
    "fieldname": "break_hours",
    "fieldtype": "Float",
-   "hidden": 0,
    "label": "Break Hours",
    "read_only": 1
   },
@@ -166,10 +165,11 @@
   }
  ],
  "links": [],
- "modified": "2024-07-24 16:45:02.502629",
+ "modified": "2024-09-01 13:44:04.729173",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Workday",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -198,5 +198,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
[#23](https://git.phamos.eu/gallehr/gallehr/-/issues/23) HR Addon Workdays

https://chat.phamos.eu/phamos/pl/sjghw9u9mjd9ic565gh5dtojyh
1. Add a validation in Workday: If hours_worked is less than 36, the user should not be allowed to save the Workday record.

<img width="1245" alt="Screenshot 2024-09-01 at 14 52 29" src="https://github.com/user-attachments/assets/d5eb6fa9-067c-4807-9fa1-93b2dc7c8d10">

2. In Workday, if a selected date has a leave application for the selected employee with the leave type 'Freizeitausgleich (Nicht buchen!),' the working hours for that day should be set to 0. Display a message to the user, but allow the record to be saved.

<img width="1247" alt="Screenshot 2024-09-01 at 14 53 11" src="https://github.com/user-attachments/assets/cd8f8cc4-8feb-41ca-ae0b-cb12ea6706a6">
<img width="1263" alt="Screenshot 2024-09-01 at 14 55 05" src="https://github.com/user-attachments/assets/b23bdb99-7623-4cc1-9bf9-46799df4d6e7">


3. Set target_hours to be read-only in Workday."