### PR TITLE
Replace frappe.utils.datetime.datetime.now by frappe.utils.get_datetime

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -61,7 +61,7 @@ def generate_workdays_scheduled_job():
         }
         
         # Get the current date and time
-        now = frappe.utils.datetime.datetime.now()
+        now = frappe.utils.get_datetime()
         today_weekday_number = now.weekday()
         weekday_name = number2name_dict[today_weekday_number]
         
@@ -88,7 +88,7 @@ def generate_workdays_scheduled_job():
 @frappe.whitelist()
 def generate_workdays_for_past_7_days_now():
     try:
-        today = frappe.utils.datetime.datetime.now()
+        today = frappe.utils.get_datetime()
         a_week_ago = today - frappe.utils.datetime.timedelta(days=7)
         frappe.logger("Creating Workday").error(f"Processing from {a_week_ago} to {today}")
         


### PR DESCRIPTION
Fixes #122 

frappe.utils.datetime.datetime.now returns the time in UTC, we need the time in German timezone, that's why we need frappe.utils.get_datetime

For example, the difference is:
```
In [1]: frappe.utils.get_datetime()
Out[1]: datetime.datetime(2024, 10, 2, 10, 31, 1, 18381)

In [2]: frappe.utils.datetime.datetime.now()
Out[2]: datetime.datetime(2024, 10, 2, 8, 31, 48, 461668)

```