### PR TITLE
add validation on duplicate workday and fetch target and break hours even if dont have checkins.

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -51,7 +51,7 @@ def get_actual_employee_log(aemployee, adate):
     # check empty or none
     if not employee_checkins:
         frappe.msgprint("No Checkin found for {0} on date {1}".format(frappe.get_desk_link("Employee", aemployee) ,adate))
-        return
+        #return
 
     employee_default_work_hour = get_employee_default_work_hour(aemployee,adate)
     is_date_in_holiday_list = date_is_in_holiday_list(aemployee,adate)
@@ -115,7 +115,7 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours, i
     if no_break_hours and hours_worked < 6: # TODO: set 6 as constant
         break_minutes = 0
         total_break_seconds = 0
-        expected_break_hours = 0
+        #expected_break_hours = 0
         actual_working_hours = hours_worked
 
     if is_target_hours_zero_on_holiday and is_date_in_holiday_list:
@@ -173,6 +173,9 @@ def get_actual_employee_log_for_bulk_process(aemployee, adate):
     else:
         view_employee_attendance = get_employee_attendance(aemployee, adate)
 
+        break_minutes = employee_default_work_hour.break_minutes
+        expected_break_hours = flt(break_minutes / 60)
+
         new_workday = {
             "target_hours": employee_default_work_hour.hours,
             "break_minutes": employee_default_work_hour.break_minutes,
@@ -181,6 +184,7 @@ def get_actual_employee_log_for_bulk_process(aemployee, adate):
             "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",
             "break_hours": 0,
             "employee_checkins":[],
+            "expected_break_hours": expected_break_hours,
         }
 
     return new_workday

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -13,6 +13,7 @@ from hr_addon.hr_addon.api.utils import get_actual_employee_log_for_bulk_process
 class Workday(Document):
     def validate(self):
         self.date_is_in_comp_off()
+        self.validate_duplicate_workday()
 		
 
     def date_is_in_comp_off(self):
@@ -32,6 +33,18 @@ class Workday(Document):
             self.break_hours = 0.0
             self.total_break_seconds = 0.0
             self.total_work_seconds = flt(self.actual_working_hours * 60 * 60)
+
+    def validate_duplicate_workday(self):
+        workday = frappe.db.exists("Workday", {
+            'employee': self.employee,
+            'log_date': self.log_date
+        })
+    
+        if workday:
+            frappe.throw(
+            _("Workday already exists for employee: {0}, on the given date: {1}")
+            .format(self.employee, frappe.utils.formatdate(self.log_date))
+            )
 
 
 def bulk_process_workdays_background(data,flag):


### PR DESCRIPTION
Problems with HR Addon

https://chat.phamos.eu/phamos/pl/6zshjzo1nfgc5km677ejr43g5o

1. We had validation for duplicate workdays on 'process workday'. Now added validation on individual workday creation.
2. added target_hours and expected break hours even if we dont have checkins

