### PR TITLE
update workday - total target seconds

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -175,9 +175,9 @@ def get_actual_employee_log_for_bulk_process(aemployee, adate):
 
         break_minutes = employee_default_work_hour.break_minutes
         expected_break_hours = flt(break_minutes / 60)
-
         new_workday = {
             "target_hours": employee_default_work_hour.hours,
+            "total_target_seconds":employee_default_work_hour.hours * 60 * 60,
             "break_minutes": employee_default_work_hour.break_minutes,
             "hours_worked": 0,
             "nbreak": 0,


### PR DESCRIPTION
[#23](https://git.phamos.eu/gallehr/gallehr/-/issues/23) HR Addon Workdays

added code for condition - days on which employee  should have clocked but there are no entries - then we should show diff log= - target hours

<img width="1121" alt="Screenshot 2024-10-07 at 13 24 13" src="https://github.com/user-attachments/assets/3fe6ed8f-eb58-43f2-bf2f-988dee805d0d">
<img width="1235" alt="Screenshot 2024-10-07 at 13 24 35" src="https://github.com/user-attachments/assets/42b91a62-9b81-407b-b613-62ce5707e403">
