### PR TITLE
feat:actual working hours = - expected hours.

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -179,6 +179,7 @@ def get_actual_employee_log_for_bulk_process(aemployee, adate):
             "target_hours": employee_default_work_hour.hours,
             "total_target_seconds":employee_default_work_hour.hours * 60 * 60,
             "break_minutes": employee_default_work_hour.break_minutes,
+            "actual_working_hours":-expected_break_hours,
             "hours_worked": 0,
             "nbreak": 0,
             "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",


### PR DESCRIPTION
https://git.phamos.eu/gallehr/gallehr/-/issues/16#note_7211

days on which employee should have clocked(no leave and no holiday) but there are no checkin entries - then diff log= - target hours and actual working hours = - expected hours.

<img width="1265" alt="Screenshot 2024-10-07 at 14 38 08" src="https://github.com/user-attachments/assets/8dd842d5-1fec-4b93-b9ed-62ecd5398f2a">
<img width="1256" alt="Screenshot 2024-10-07 at 14 38 18" src="https://github.com/user-attachments/assets/ff9f7e6b-628a-47a5-9ed9-7e425e9b8199">

