### PR TITLE
Update diff log for workday hour report

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -179,7 +179,7 @@ def get_actual_employee_log_for_bulk_process(aemployee, adate):
             "target_hours": employee_default_work_hour.hours,
             "total_target_seconds":employee_default_work_hour.hours * 60 * 60,
             "break_minutes": employee_default_work_hour.break_minutes,
-            "actual_working_hours":-expected_break_hours,
+            "actual_working_hours":0,
             "hours_worked": 0,
             "nbreak": 0,
             "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -14,7 +14,6 @@ class Workday(Document):
     def validate(self):
         self.date_is_in_comp_off()
         self.validate_duplicate_workday()
-		
 
     def date_is_in_comp_off(self):
     # Check if a comp off leave application exists for the given employee and date
@@ -33,6 +32,9 @@ class Workday(Document):
             self.break_hours = 0.0
             self.total_break_seconds = 0.0
             self.total_work_seconds = flt(self.actual_working_hours * 60 * 60)
+        elif self.hours_worked <= 0:
+            self.actual_working_hours = 0.0
+    
 
     def validate_duplicate_workday(self):
         workday = frappe.db.exists("Workday", {

--- a/hr_addon/hr_addon/report/work_hour_report/work_hour_report.py
+++ b/hr_addon/hr_addon/report/work_hour_report/work_hour_report.py
@@ -61,7 +61,11 @@ def execute(filters=None):
             THEN 0
             ELSE total_work_seconds
         END - total_target_seconds) AS diff_log,
-        (actual_working_hours * 60 * 60 - total_target_seconds) AS actual_diff_log,
+		(CASE 
+            WHEN actual_working_hours < 0 
+            THEN (0 - total_target_seconds)
+            ELSE (actual_working_hours * 60 * 60 - total_target_seconds)
+        END) AS actual_diff_log,
         TIME(first_checkin) AS first_in,
         TIME(last_checkout) AS last_out 
     FROM `tabWorkday` 
@@ -75,3 +79,4 @@ def execute(filters=None):
 	data = work_data
 
 	return columns, data
+#(actual_working_hours * 60 * 60 - total_target_seconds) AS actual_diff_log,64to68


### PR DESCRIPTION
[#23](https://git.phamos.eu/gallehr/gallehr/-/issues/23) HR Addon Workdays
https://chat.phamos.eu/phamos/pl/6zshjzo1nfgc5km677ejr43g5o

Test and update  - workday hour report calculation - 

1. Workday with check-ins and no leave shows the correct difference in the log.


<img width="1262" alt="Screenshot 2024-10-08 at 11 00 33" src="https://github.com/user-attachments/assets/6941ef82-c5fb-402b-b4ed-5b637c6c78a0">

2. If workday - date and employee have - Freizeitausgleich (Nicht buchen!) - then diff log will be -target_hours

<img width="1275" alt="Screenshot 2024-10-08 at 11 02 35" src="https://github.com/user-attachments/assets/8bcd7358-eed2-454e-a997-795d53c260a4">

3. workday - with weekly working hours but no checkins - then diff log will be -target_hours

<img width="1265" alt="Screenshot 2024-10-08 at 11 04 15" src="https://github.com/user-attachments/assets/f06eb1fb-8001-4f5a-8d3a-63a2569ebcab">

4. workday - with leave application - diff log - will be - target_hours
<img width="1260" alt="Screenshot 2024-10-08 at 11 06 24" src="https://github.com/user-attachments/assets/3dfc97f1-4d17-47b2-95be-7b94b90c6fb9">

