### PR TITLE
Version 15

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -2,11 +2,9 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils.data import date_diff, time_diff_in_hours
-from frappe.utils import get_datetime, getdate, today, comma_sep, flt,add_days, date_diff, cstr
+from frappe.utils import get_datetime, getdate, today, comma_sep, flt,add_days, date_diff
 from frappe.core.doctype.role.role import get_info_based_on_role
 from frappe.query_builder import DocType
-from frappe.query_builder import DocType
-from frappe.query_builder.functions import Count
 
 
 def get_employee_checkin(employee,atime):

--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -340,7 +340,8 @@ def date_is_in_holiday_list(employee, date):
 # WORK ANNIVERSARY REMINDERS SEND TO EMPLOYEES LIST IN HR-ADDON-SETTINGS
 # ----------------------------------------------------------------------
 def send_work_anniversary_notification():
-    if not int(frappe.db.get_single_value("HR Addon Settings", "enable_work_anniversaries_notification")):
+    hr_addon_settings = frappe.get_single("HR Addon Settings")
+    if not hr_addon_settings.enable_work_anniversaries_notification:
         return
     
     """
@@ -374,8 +375,8 @@ def send_work_anniversary_notification():
     """
         Sending email to specified employees with Role in HR Addon Settings field anniversary_notification_email_recipient_role
     """
-    email_recipient_role = frappe.db.get_single_value("HR Addon Settings", "anniversary_notification_email_recipient_role")
-    notification_x_days_before = int(frappe.db.get_single_value("HR Addon Settings", "notification_x_days_before"))
+    email_recipient_role = hr_addon_settings.anniversary_notification_email_recipient_role
+    notification_x_days_before = hr_addon_settings.notification_x_days_before
     joining_date = frappe.utils.add_days(today(), notification_x_days_before)
     employees_joined_seven_days_later = get_employees_having_an_event_on_given_date("work_anniversary", joining_date)
     if email_recipient_role:
@@ -396,7 +397,7 @@ def send_work_anniversary_notification():
         Sending email to specified employee leave approvers if HR Addon Settings field 
         enable_work_anniversaries_notification_for_leave_approvers is checked
     """
-    if int(frappe.db.get_single_value("HR Addon Settings", "enable_work_anniversaries_notification_for_leave_approvers")):
+    if int(hr_addon_settings.enable_work_anniversaries_notification_for_leave_approvers):
         leave_approvers_email_list = {}
         for company, anniversary_persons in employees_joined_seven_days_later.items():
             leave_approvers_email_list.setdefault(company, {"leave_approver_missing": [], "leave_approver_not_active": []})

--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -371,7 +371,9 @@ def send_work_anniversary_notification():
     employees_joined_today = get_employees_having_an_event_on_given_date("work_anniversary", joining_date)
     send_emails(employees_joined_today, recipients, joining_date)
 
-    ############## Sending email to specified employees with Role in HR Addon Settings field anniversary_notification_email_recipient_role
+    """
+        Sending email to specified employees with Role in HR Addon Settings field anniversary_notification_email_recipient_role
+    """
     email_recipient_role = frappe.db.get_single_value("HR Addon Settings", "anniversary_notification_email_recipient_role")
     notification_x_days_before = int(frappe.db.get_single_value("HR Addon Settings", "notification_x_days_before"))
     joining_date = frappe.utils.add_days(today(), notification_x_days_before)

--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -370,7 +370,7 @@ def send_work_anniversary_notification():
 
     joining_date = today()
     employees_joined_today = get_employees_having_an_event_on_given_date("work_anniversary", joining_date)
-    send_emails(employees_joined_today, recipients, joining_date)
+    send_work_anniversary_reminder(employees_joined_today, recipients, joining_date)
 
     """
         Sending email to specified employees with Role in HR Addon Settings field anniversary_notification_email_recipient_role
@@ -390,7 +390,7 @@ def send_work_anniversary_notification():
                 # TODO: if user not found in employee, then what?
                 pass
 
-        send_emails(employees_joined_seven_days_later, role_email_recipients, joining_date)
+        send_work_anniversary_reminder(employees_joined_seven_days_later, role_email_recipients, joining_date)
 
     """
         Sending email to specified employee leave approvers if HR Addon Settings field 
@@ -418,16 +418,15 @@ def send_work_anniversary_notification():
             for leave_approver, anniversary_persons in leave_approvers_email_list_by_company.items():
                 if leave_approver not in ["leave_approver_missing", "leave_approver_not_active"]:
                     reminder_text, message = get_work_anniversary_reminder_text_and_message(anniversary_persons, joining_date)
-                    send_work_anniversary_reminder(leave_approver, reminder_text, anniversary_persons, message)
+                    send_emails(leave_approver, reminder_text, anniversary_persons, message)
 
 
-def send_emails(employees_joined_today, recipients, joining_date):
-
+def send_work_anniversary_reminder(employees_joined_today, recipients, joining_date):
     for company, anniversary_persons in employees_joined_today.items():
         reminder_text, message = get_work_anniversary_reminder_text_and_message(anniversary_persons, joining_date)
         recipients_by_company = [d.get('employee_email') for d in recipients if d.get('company') == company ]
         if recipients_by_company:
-            send_work_anniversary_reminder(recipients_by_company, reminder_text, anniversary_persons, message)
+            send_emails(recipients_by_company, reminder_text, anniversary_persons, message)
 
 
 def get_employees_having_an_event_on_given_date(event_type, date):
@@ -505,7 +504,7 @@ def get_work_anniversary_reminder_text_and_message(anniversary_persons, joining_
     return reminder_text, message
 
 
-def send_work_anniversary_reminder(recipients, reminder_text, anniversary_persons, message):
+def send_emails(recipients, reminder_text, anniversary_persons, message):
     frappe.sendmail(
         recipients=recipients,
         subject=_("Work Anniversary Reminder"),

--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -383,15 +383,14 @@ def send_work_anniversary_notification():
         role_email_recipients = []
         users_with_role = get_info_based_on_role(email_recipient_role, field="email")
         for user in users_with_role:
-            user_data = frappe.get_cached_value("Employee", {"user_id": user}, ["company", "user_id"], as_dict=True)
+            user_data = frappe.get_cached_value("Employee", {"user_id": user, "status": "Active"}, ["company"], as_dict=True)
             if user_data:
-                role_email_recipients.extend([{"employee_email": user_data.get("user_id"), "company": user_data.get("company")}])
+                role_email_recipients.extend([{"employee_email": user, "company": user_data.get("company")}])
             else:
                 # TODO: if user not found in employee, then what?
                 pass
 
-        if role_email_recipients:
-            send_emails(employees_joined_seven_days_later, role_email_recipients, joining_date)
+        send_emails(employees_joined_seven_days_later, role_email_recipients, joining_date)
 
     """
         Sending email to specified employee leave approvers if HR Addon Settings field 

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -3,6 +3,13 @@
 
 frappe.ui.form.on('HR Addon Settings', {
 	refresh: function(frm) {
+        frm.set_query("anniversary_notification_email_list", function () {
+            return {
+                filters: {
+                    status: "Active",
+                },
+            };
+        });
 	},
 
 	validate: function(frm){


### PR DESCRIPTION
[#77](https://git.phamos.eu/suncycle/suncycle/-/issues/77) Work Anniversary Reminder

https://chat.phamos.eu/phamos/pl/u5bstdbeu3gjbbhy73p7zjcquc

1. refilter above before send email, because it a possibility that at some later point Email set in 'Anniversary Notification Email List' in 'HR Addon Settings' become inactive
2. Filter role based inactive employees  
3. Filter inactive employees who are set as leave approver in some other employees 
4. Refactored to avoid multiple db call for Hr Addon Settings
5. Cleanup and set relevant function names