### PR TITLE
Fixes for manual Workday (Adjusted Workdays)

### DIFF
--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -87,6 +87,7 @@ def get_actual_employee_log(aemployee, adate):
                 "total_target_seconds": employee_default_work_hour.hours * 60 * 60,
                 "break_minutes": employee_default_work_hour.break_minutes,
                 "actual_working_hours": -employee_default_work_hour.hours,
+                "manual_workday": 1,
                 "hours_worked": 0,
                 "nbreak": 0,
                 "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",

--- a/hr_addon/hr_addon/api/utils.py
+++ b/hr_addon/hr_addon/api/utils.py
@@ -247,6 +247,7 @@ def get_actual_employee_log_for_bulk_process(aemployee, adate):
                 "total_target_seconds": employee_default_work_hour.hours * 60 * 60,
                 "break_minutes": employee_default_work_hour.break_minutes,
                 "actual_working_hours": -employee_default_work_hour.hours,
+                "manual_workday": 1,
                 "hours_worked": 0,
                 "nbreak": 0,
                 "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",

--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -91,7 +91,7 @@ var get_hours = function (frm) {
           frm.set_value("target_hours", alog.target_hours);
           frm.set_value("expected_break_hours", alog.expected_break_hours);
           frm.set_value("total_target_seconds", alog.total_target_seconds);
-
+          frm.set_value("manual_workday",alog.manual_workday);
           frm.set_value("actual_working_hours", alog.actual_working_hours);
           let employee_checkins = alog.employee_checkins;
           if (employee_checkins) {

--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -94,7 +94,7 @@ var get_hours = function (frm) {
           frm.set_value("manual_workday",alog.manual_workday);
           frm.set_value("actual_working_hours", alog.actual_working_hours);
           let employee_checkins = alog.employee_checkins;
-          if (employee_checkins) {
+          if (employee_checkins.length > 0) {
             frm.set_value("first_checkin", employee_checkins[0].time);
             frm.set_value(
               "last_checkout",

--- a/hr_addon/hr_addon/doctype/workday/workday.json
+++ b/hr_addon/hr_addon/doctype/workday/workday.json
@@ -12,6 +12,7 @@
   "acolumn_break_1",
   "log_date",
   "status",
+  "manual_workday",
   "section_break_7",
   "employee_checkins",
   "section_break_9",
@@ -162,10 +163,17 @@
    "fieldtype": "Float",
    "label": "Expected Break Hours",
    "permlevel": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "manual_workday",
+   "fieldtype": "Check",
+   "label": "Manual Workday",
+   "permlevel": 1
   }
  ],
  "links": [],
- "modified": "2024-10-11 16:53:27.398465",
+ "modified": "2024-11-13 16:45:45.592647",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Workday",

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -15,6 +15,7 @@ class Workday(Document):
         self.date_is_in_comp_off()
         self.validate_duplicate_workday()
         self.set_status_for_leave_application()
+        # self.set_manual_workday()
 
     def set_status_for_leave_application(self):
         leave_application = frappe.db.exists(
@@ -68,11 +69,17 @@ class Workday(Document):
             'log_date': self.log_date
         })
     
-        if workday:
+        if workday and self.is_new():
             frappe.throw(
             _("Workday already exists for employee: {0}, on the given date: {1}")
             .format(self.employee, frappe.utils.formatdate(self.log_date))
             )
+
+    # def set_manual_workday(self):
+    #     if self.manual_workday:
+    #         self.employee_checkins = []
+    #         self.total_work_seconds = self.hours_worked * 60 * 60
+    #         self.expected_break_hours = 0.0
 
 
 def bulk_process_workdays_background(data,flag):

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -138,7 +138,8 @@ def bulk_process_workdays(data,flag):
                     "expected_break_hours": single.get("expected_break_hours"),
                     "total_break_seconds": single.get("total_break_seconds"),
                     "total_target_seconds": single.get("total_target_seconds"),
-                    "actual_working_hours": single.get("actual_working_hours")
+                    "actual_working_hours": single.get("actual_working_hours"),
+                    "manual_workday": single.get("manual_workday")
                 }
 
             workday = frappe.get_doc(doc_dict)

--- a/hr_addon/hr_addon/report/work_hour_report/work_hour_report.js
+++ b/hr_addon/hr_addon/report/work_hour_report/work_hour_report.js
@@ -113,8 +113,8 @@ frappe.query_reports["Work Hour Report"] = {
 
 		if (column.fieldname == "actual_diff_log" ) {
 			if(value < 0) {
-				value = "<span style='color:#FF8C00'>" + hitt(value,true) + "</span>";
-				
+				// value = "<span style='color:#FF8C00'>" + hitt(value,true) + "</span>";
+				value = "<span style='color:red'>" +"-"+ hitt(value,true) + "</span>";
 			}
 			else if(value > 0){
 				value = "<span style='color:blue'>" + hitt(value,true) + "</span>";

--- a/hr_addon/hr_addon/report/work_hour_report/work_hour_report.py
+++ b/hr_addon/hr_addon/report/work_hour_report/work_hour_report.py
@@ -31,7 +31,7 @@ def execute(filters=None):
 		{'fieldname':'actual_working_seconds','label':_('Actual Working Hours'), "width": 110, },
 		{'fieldname':'total_target_seconds','label':'Target Seconds','width':80},
 		# {'fieldname':'diff_log','label':'Diff (Work Hours - Target Seconds)','width':90},
-		{'fieldname':'actual_diff_log','label':'Diff (Actual Working Hours - Target Seconds)','width':90},
+		{'fieldname':'actual_diff_log','label':'Diff (Actual Working Hours - Target Seconds)','width':110},
 		{'fieldname':'first_in','label':'First Checkin','width':100},
 		{'fieldname':'last_out','label':'Last Checkout','width':100},
 		{'fieldname':'attendance','label':'Attendance','width': 160},
@@ -63,7 +63,7 @@ def execute(filters=None):
         END - total_target_seconds) AS diff_log,
 		(CASE 
             WHEN actual_working_hours < 0 
-            THEN (0 - total_target_seconds)
+            THEN actual_working_hours * 60 * 60
             ELSE (actual_working_hours * 60 * 60 - total_target_seconds)
         END) AS actual_diff_log,
         TIME(first_checkin) AS first_in,


### PR DESCRIPTION
https://git.phamos.eu/gallehr/gallehr/-/issues/51

1. Added field Manual Workdays:
![image](https://github.com/user-attachments/assets/54dd3d28-69cb-4aae-88b0-3678797d255c)

set manual workday if no employee_checkins and day is not working day when workdata processed via:
                1. Bulk Processing
                2. Background job
                3. Triggering Date and Attendance field from Workday field

2. Set Diff column same as Actual Hours (actual_working_hours) if actual_working_hours is negative:
![image](https://github.com/user-attachments/assets/65a6ef9f-a32f-4a66-973a-09ab05b8ec7f)
