### PR TITLE
Disable the 6 Hours work function

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.json
+++ b/hr_addon/hr_addon/doctype/workday/workday.json
@@ -173,7 +173,7 @@
   }
  ],
  "links": [],
- "modified": "2024-11-13 16:45:45.592647",
+ "modified": "2024-12-05 22:28:58.266573",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Workday",
@@ -223,6 +223,13 @@
    "report": 1,
    "role": "HR Manager",
    "share": 1
+  },
+  {
+   "export": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
+   "select": 1
   }
  ],
  "sort_field": "modified",

--- a/hr_addon/hr_addon/report/work_hour_report/work_hour_report.json
+++ b/hr_addon/hr_addon/report/work_hour_report/work_hour_report.json
@@ -10,7 +10,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letter_head": "Sunlight",
- "modified": "2022-06-03 00:18:21.420312",
+ "modified": "2024-12-05 22:27:41.292454",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Work Hour Report",
@@ -28,6 +28,9 @@
   },
   {
    "role": "HR Manager"
+  },
+  {
+   "role": "Employee"
   }
  ]
 }


### PR DESCRIPTION
https://git.phamos.eu/gallehr/gallehr/-/work_items/66

Description: 
1. Disable the 6 Hours work function if  "Workday break Calculation Mechanism" is "Break Hours from Employee Checkins" and "Swap Hours worked and Actual Working Hours" is checked. As seen in screenshot below:
![image](https://github.com/user-attachments/assets/a9a7a1b0-e990-42a2-9f42-251525046514)

Demo:

https://github.com/user-attachments/assets/03108577-a60c-4b04-88d6-fb07c823694b


2. Added Permission for Report "Work Hour Report" and "Workday" Doctype for Role Employee
![image](https://github.com/user-attachments/assets/d1444df8-b500-4d4e-a7eb-6dfc584d3058)
![image](https://github.com/user-attachments/assets/780f2063-1678-4a4d-a57c-d8814cdd4dde)

