### PR TITLE
refactor/7-move-list_view-to-weekly_working_hours

### DIFF
--- a/hr_addon/hooks.py
+++ b/hr_addon/hooks.py
@@ -199,7 +199,6 @@ doc_events = {
     }
 }
 
-doctype_list_js = {"Weekly Working Hours" : "public/js/list_view.js"}
 
 scheduler_events = {
 	"hourly": [

--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours_list.js
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours_list.js
@@ -1,4 +1,3 @@
-frappe.provide("hr_addon.frappe.views");
 frappe.listview_settings["Weekly Working Hours"] = {
 	onload: function (list_view) {
 		
@@ -13,5 +12,3 @@ frappe.listview_settings["Weekly Working Hours"] = {
 		
 	},
 };
-
-


### PR DESCRIPTION
- Moved the public/list_view.js file code to weekly_working_hours_list.js new file
- Removed the list_view.js file
- Removed the list_view call from hooks.py file