### PR TITLE
refactor/11-use-frappe.query_builder-over-frappe.db.sql-v15

### DIFF
--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
@@ -9,7 +9,14 @@ from frappe import _
 
 class WeeklyWorkingHours(Document):
 	def autoname(self):
-		coy = frappe.db.sql("select abbr from tabCompany where name=%s", self.company)[0][0]
+		Company = frappe.qb.DocType('Company')
+		query = (
+			frappe.qb.from_(Company)
+			.select(Company.abbr)
+			.where(Company.name == self.company)
+		).run()
+
+		coy = query[0][0] if query else None
 		e_name = self.employee
 		name_key = coy+'-.YYYY.-'+e_name+'-.####'
 		self.name = make_autoname(name_key)
@@ -36,61 +43,67 @@ class WeeklyWorkingHours(Document):
 
 		filters = {"valid_from": valid_from, "valid_to": valid_to, "employee": self.employee}
 
-		condition = ""
-		if not self.is_new():
-			condition += "AND name != %(name)s "
-			filters["name"] = self.name
-
-		overlapping_records = frappe.db.sql("""
-			SELECT name 
-			FROM `tabWeekly Working Hours`
-			WHERE 
+		wwh = frappe.qb.DocType("Weekly Working Hours")
+		overlapping_records = (
+			frappe.qb.from_(wwh)
+			.select(wwh.name)
+			.where(
 				(
-					(valid_from <= %(valid_from)s AND valid_to >= %(valid_to)s) OR
-					(valid_from <= %(valid_from)s AND valid_to >= %(valid_to)s) OR
-					(valid_from >= %(valid_from)s AND valid_to <= %(valid_to)s)
-				) AND employee = %(employee)s AND docstatus = 1 {condition}
-			""".format(condition=condition), filters, as_dict=True)
+					(wwh.valid_from <= filters["valid_from"])
+					& (wwh.valid_to >= filters["valid_to"])
+				)
+				| (
+					(wwh.valid_from >= filters["valid_from"])
+					& (wwh.valid_to <= filters["valid_to"])
+				)
+			)
+			.where(wwh.employee == filters["employee"])
+			.where(wwh.docstatus == 1)
+		)
 
-		if overlapping_records:
-			overlapping_records = "<br> ".join([frappe.get_desk_link("Weekly Working Hours", d.name) for d in overlapping_records])
-			frappe.throw("Following Weekly Working Hours record already exists for {0} for the specified date range:<br> {1}".format(frappe.get_desk_link("Employee", self.employee), overlapping_records))
+		if not self.is_new():
+			filters["name"] = self.name
+			overlapping_records = overlapping_records.where(wwh.name != filters["name"])
+
+		results = overlapping_records.run(as_dict=True)
+
+		if results:
+			overlapping_links = "<br> ".join([frappe.get_desk_link("Weekly Working Hours", d.name) for d in results])
+			frappe.throw("Following Weekly Working Hours record already exists for {0} for the specified date range:<br> {1}".format(
+				frappe.get_desk_link("Employee", self.employee), overlapping_links))
 
 
 @frappe.whitelist()
 def set_from_to_dates():
     # Ensure fiscal year data is present
-    fiscal_year = frappe.db.sql("""
-        SELECT year_start_date, year_end_date 
-        FROM `tabFiscal Year` 
-        WHERE disabled = 0
-    """, as_dict=True)
-    
-    if not fiscal_year:
-        frappe.throw("No active fiscal year found.")
-    
-    year_start_date = fiscal_year[0].year_start_date
-    year_end_date = fiscal_year[0].year_end_date
+	FiscalYear = frappe.qb.DocType('Fiscal Year')
+	fiscal_year = (
+		frappe.qb.from_(FiscalYear)
+		.select(FiscalYear.year_start_date ,FiscalYear.year_end_date)
+		.where(FiscalYear.disabled == 0)
+	).run(as_dict=True)
 
-    # Update the valid_from and valid_to fields
-    frappe.db.sql("""
-        UPDATE
-            `tabWeekly Working Hours`
-        SET
-            valid_from = %(year_start_date)s,
-            valid_to = %(year_end_date)s
-        WHERE
-            employee IN (
-                SELECT
-                    name
-                FROM
-                    `tabEmployee`
-                WHERE
-                    permanent = 1
-            )
-    """, {
-        "year_start_date": year_start_date,
-        "year_end_date": year_end_date
-    })
+	if not fiscal_year:
+		frappe.throw("No active fiscal year found.")
     
-    frappe.db.commit()
+	year_start_date = fiscal_year[0].year_start_date
+	year_end_date = fiscal_year[0].year_end_date
+
+	# Update the valid_from and valid_to fields
+	wwh = frappe.qb.DocType("Weekly Working Hours")
+	Employee = frappe.qb.DocType("Employee")
+
+	subquery = (
+		frappe.qb.from_(Employee)
+		.select(Employee.name)
+		.where(Employee.permanent == 1)
+	)
+
+	update_query = (
+		frappe.qb.update(wwh)
+		.set(wwh.valid_from, year_start_date)
+		.set(wwh.valid_to, year_end_date)
+		.where(wwh.employee.isin(subquery))
+	).run()
+
+	frappe.db.commit()

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -555,7 +555,7 @@ def get_employee_attendance(employee,atime):
 
 @frappe.whitelist()
 def date_is_in_holiday_list(employee, date):
-    holiday_list = frappe.db.get_value("Employee", employee, "holiday_list")
+    holiday_list = frappe.get_cached_value("Employee", employee, "holiday_list")
     if not holiday_list:
         frappe.msgprint(_("Holiday list not set in {0}").format(employee))
         return False

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -7,6 +7,9 @@ from frappe.model.document import Document
 from frappe.utils import cint, get_datetime, getdate, add_days, flt
 from frappe.utils.data import date_diff, time_diff_in_hours
 from frappe.query_builder import DocType
+from pypika import Order
+from pypika.functions import Date
+from datetime import datetime
 import traceback
 
 
@@ -224,12 +227,22 @@ def get_employee_checkin(employee,atime):
     ''' select DATE('date time');'''
     employee = employee
     atime = atime
-    checkin_list = frappe.db.sql(
-        """
-        SELECT  name,log_type,time,skip_auto_attendance,attendance FROM `tabEmployee Checkin` 
-        WHERE employee='%s' AND DATE(time)= DATE('%s') ORDER BY time ASC
-        """%(employee,atime), as_dict=1
-    )
+
+    EmployeeCheckin = frappe.qb.DocType('Employee Checkin')
+    checkin_list = (
+        frappe.qb.from_(EmployeeCheckin)
+        .select(
+            EmployeeCheckin.name,
+            EmployeeCheckin.log_type,
+            EmployeeCheckin.time,
+            EmployeeCheckin.skip_auto_attendance,
+            EmployeeCheckin.attendance
+        )
+        .where(EmployeeCheckin.employee == employee)
+        .where(Date(EmployeeCheckin.time) == getdate(atime))
+        .orderby(EmployeeCheckin.time, order=Order.asc)
+    ).run(as_dict=1)
+
     return checkin_list or []
 
 def get_employee_default_work_hour(aemployee,adate):
@@ -521,30 +534,41 @@ def get_employee_attendance(employee,atime):
     employee = employee
     atime = atime
     
-    attendance_list = frappe.db.sql(
-        """
-        SELECT  name,employee,status,attendance_date,shift FROM `tabAttendance` 
-        WHERE employee='%s' AND DATE(attendance_date)= DATE('%s') AND docstatus = 1 ORDER BY attendance_date ASC
-        """%(employee,atime), as_dict=1
-    )
+    Attendance = frappe.qb.DocType('Attendance')
+    attendance_list = (
+        frappe.qb.from_(Attendance)
+        .select(
+            Attendance.name,
+            Attendance.employee,
+            Attendance.status,
+            Attendance.attendance_date,
+            Attendance.shift
+        )
+        .where(Attendance.employee == employee)
+        .where(Date(Attendance.attendance_date) == getdate(atime))
+        .where(Attendance.docstatus == 1)
+        .orderby(Attendance.attendance_date, order=Order.asc)
+    ).run(as_dict=True)
+
     return attendance_list
 
 
 @frappe.whitelist()
 def date_is_in_holiday_list(employee, date):
-	holiday_list = frappe.db.get_value("Employee", employee, "holiday_list")
-	if not holiday_list:
-		frappe.msgprint(_("Holiday list not set in {0}").format(employee))
-		return False
+    holiday_list = frappe.db.get_value("Employee", employee, "holiday_list")
+    if not holiday_list:
+        frappe.msgprint(_("Holiday list not set in {0}").format(employee))
+        return False
 
-	holidays = frappe.db.sql(
-        """
-            SELECT holiday_date FROM `tabHoliday`
-            WHERE parent=%s AND holiday_date=%s
-        """,(holiday_list, getdate(date))
-    )
+    Holiday = frappe.qb.DocType('Holiday')
+    holidays = (
+        frappe.qb.from_(Holiday)
+        .select(Holiday.holiday_date)
+        .where(Holiday.parent == holiday_list)
+        .where(Holiday.holiday_date == getdate(date))
+    ).run()
 
-	return len(holidays) > 0
+    return len(holidays) > 0
 
 
 def generate_workdays_scheduled_job():


### PR DESCRIPTION
- Task: [#11](https://git.phamos.eu/phamos/hr-department/-/work_items/11)
- Replaced `frappe.db.sql` with `frappe.query_builder`.
- Replaced `frappe.db.get_value` with `frappe.get_cached_value`.