### PR TITLE
Workday Error Solution

### DIFF
--- a/hr_addon/datafox/api.py
+++ b/hr_addon/datafox/api.py
@@ -1,0 +1,82 @@
+import frappe
+from frappe import _
+from frappe.utils import now_datetime, getdate
+from datetime import datetime
+
+@frappe.whitelist(allow_guest=True)
+def handle_rfid_scan(**kwargs):
+    """Handle incoming Datafox RFID scan requests"""
+    
+    # Validate mandatory parameters
+    if not all(k in kwargs for k in ['df_col_df_name', 'df_col_Datum']):
+        frappe.throw(_("Missing required parameters: df_col_df_name and df_col_Datum"))
+
+    badge_id = kwargs.get('df_col_df_name')
+    scan_time = kwargs.get('df_col_Datum')
+    device_id = kwargs.get('df_col_df_serial', 'Unknown Device')
+    log_direction = kwargs.get('df_col_Kennung')  # "K" or "G"
+    try:
+        # Parse datetime
+        scan_datetime = datetime.strptime(scan_time, "%Y-%m-%dT%H:%M:%S")
+
+        # Get employee by badge ID
+        employee = frappe.get_value("Employee", 
+            {"attendance_device_id": badge_id}, 
+            ["name", "employee_name"], 
+            as_dict=True)
+
+        if not employee:
+            return {
+                "df_api": 0,
+                "df_msg": "Employee not found"
+            }
+
+        # Convert Kennung to log_type
+        log_type = "IN" if log_direction.upper() == "K" else "OUT"
+
+        # Check for existing checkin with same time and log_type
+        existing = frappe.db.exists("Employee Checkin", {
+            "employee": employee.name,
+            "time": scan_datetime,
+            "log_type": log_type
+        })
+
+        if existing:
+            return {
+                "df_api": 0,
+                "df_msg": f"{log_type} already recorded at {scan_datetime}"
+            }
+        
+        # Save new Employee Checkin
+        doc = frappe.get_doc({
+            "doctype": "Employee Checkin",
+            "employee": employee.name,
+            "employee_name": employee.employee_name,
+            "log_type": log_type,
+            "time": scan_datetime,
+            "device_id": device_id
+        })
+        doc.insert()
+        frappe.db.commit()
+
+        return {
+            "df_api": 1,
+            "df_time": now_datetime().strftime("%Y-%m-%dT%H:%M:%S"),
+            "df_beep": 1 if log_type == "IN" else 2,
+            "df_msg": f"{'Checked in' if log_type == 'IN' else 'Checked out'}: {employee.employee_name}"
+        }
+
+    except Exception as e:
+        frappe.log_error(f"Datafox RFID Error: {str(e)}")
+        return {
+            "df_api": 0,
+            "df_msg": "System error. Please report."
+        }
+
+def calculate_working_hours(check_in, check_out):
+    """Calculate working hours between two time objects"""
+    if not all([check_in, check_out]):
+        return 0
+        
+    delta = datetime.combine(getdate(), check_out) - datetime.combine(getdate(), check_in)
+    return delta.seconds / 3600  # Convert to hours

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -471,9 +471,17 @@ def generate_workdays_for_past_7_days_now():
 		try:
 			employee_name = employee["name"]
 			unmarked_days = get_unmarked_range(employee_name, a_week_ago.strftime("%Y-%m-%d"), today.strftime("%Y-%m-%d"))
+			valid_unmarked_days = []
+			for date in unmarked_days:
+				if has_valid_weekly_working_hours(employee_name, date):
+					valid_unmarked_days.append(date)
+			
+			if not valid_unmarked_days:
+				continue  # No valid dates, skip
+
 			data = {
 				"employee": employee_name,
-				"unmarked_days": unmarked_days
+				"unmarked_days": valid_unmarked_days
 			}
 			flag = "Create workday"
 
@@ -483,6 +491,36 @@ def generate_workdays_for_past_7_days_now():
 				"Creating Workday, Got Error: {} while fetching unmarked days for: {}".format(str(e), employee_name),
 				"Error during fetching unmarked days"
 			)
+
+def has_valid_weekly_working_hours(employee, date):
+	date = frappe.utils.getdate(date)
+	dayname = date.strftime('%A')
+
+	weekly_hours = frappe.db.get_all(
+		"Weekly Working Hours",
+		filters={
+			"employee": employee,
+			"docstatus": 1,
+			"valid_from": ["<=", date],
+			"valid_to": [">=", date],
+		},
+		fields=["name"]
+	)
+
+	if not weekly_hours:
+		return False
+
+	parent_names = [wh.name for wh in weekly_hours]
+
+	daily_hours = frappe.db.exists(
+		"Daily Hours Detail",
+		{
+			"parent": ["in", parent_names],
+			"day": dayname
+		}
+	)
+
+	return True if daily_hours else False 			
 
 
 def bulk_process_workdays_background(data,flag):

--- a/hr_addon/modules.txt
+++ b/hr_addon/modules.txt
@@ -1,1 +1,2 @@
 HR Addon
+DataFox


### PR DESCRIPTION
#179 

Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/748
Child : https://git.phamos.eu/suncycle/suncycle/-/work_items/760

Description : 
In the `generate_workdays_for_past_7_days_now` function, to avoid error logs, updated function generate_workdays_for_past_7_days_now to create workdays for days for which weekly working hours record is available 

<img width="789" alt="Screenshot 2025-04-28 at 17 45 50" src="https://github.com/user-attachments/assets/90629542-721e-4e05-b8d2-d7a6060a68e6" />
<img width="1216" alt="Screenshot 2025-04-28 at 17 45 37" src="https://github.com/user-attachments/assets/044e82b7-d757-429d-b78e-a8def1c558ef" />
<img width="1140" alt="Screenshot 2025-04-28 at 17 45 15" src="https://github.com/user-attachments/assets/f73946dc-43e1-48fe-beea-bfe93d8d7dac" />


# Description
This PR introducing the API for Datafox, we can call it as version 1, because it has initial features. It will just get the reponse from Datafox and create an Employee Checkin record into the system. To test this API, we used a rest client for now. 
https://github.com/phamos-eu/HR-Addon/pull/182