### PR TITLE
Feat/97/refactoring hr addon settings porting from v14 v15

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -20,7 +20,6 @@
   "column_break_jozi",
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
-  "enable_default_break_hour_for_shorter_breaks",
   "notification_section",
   "anniversary_notification_email_list",
   "enable_work_anniversaries_notification",
@@ -150,13 +149,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
-   "description": "While Generating Workdays, if user took shorter breaks than default break defined in 'Weekly Working Hours'. Then use default break time in calculation",
-   "fieldname": "enable_default_break_hour_for_shorter_breaks",
-   "fieldtype": "Check",
-   "label": "Enable default break hour for shorter breaks"
-  },
-  {
    "default": "Break Hours from Employee Checkins",
    "fieldname": "workday_break_calculation_mechanism",
    "fieldtype": "Select",
@@ -165,6 +157,7 @@
   },
   {
    "default": "0",
+   "depends_on": "doc.workday_break_calculation_mechanism == \"Break Hours from Employee Checkins\"",
    "fieldname": "swap_hours_worked_and_actual_working_hours",
    "fieldtype": "Check",
    "label": "Swap Hours worked and Actual Working Hours"
@@ -173,7 +166,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-22 11:00:35.052291",
+ "modified": "2025-07-24 12:53:32.868699",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -18,6 +18,8 @@
   "generate_workdays_for_past_7_days_now",
   "enabled",
   "column_break_jozi",
+  "workday_break_calculation_mechanism",
+  "swap_hours_worked_and_actual_working_hours",
   "enable_default_break_hour_for_shorter_breaks",
   "notification_section",
   "anniversary_notification_email_list",
@@ -153,12 +155,25 @@
    "fieldname": "enable_default_break_hour_for_shorter_breaks",
    "fieldtype": "Check",
    "label": "Enable default break hour for shorter breaks"
+  },
+  {
+   "default": "Break Hours from Employee Checkins",
+   "fieldname": "workday_break_calculation_mechanism",
+   "fieldtype": "Select",
+   "label": "Workday break Calculation Mechanism",
+   "options": "Break Hours from Employee Checkins\nBreak Hours from Weekly Working Hours\nBreak Hours from Weekly Working Hours if Shorter breaks"
+  },
+  {
+   "default": "0",
+   "fieldname": "swap_hours_worked_and_actual_working_hours",
+   "fieldtype": "Check",
+   "label": "Swap Hours worked and Actual Working Hours"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-01 16:50:41.571435",
+ "modified": "2025-07-22 11:00:35.052291",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",
@@ -185,6 +200,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -326,15 +326,18 @@ def get_actual_employee_log(aemployee, adate):
 
 
 def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
+    hr_addon_settings = frappe.get_cached_doc("HR Addon Settings")
+    is_break_from_checkins_with_swapped_hours = hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Employee Checkins" and hr_addon_settings.swap_hours_worked_and_actual_working_hours
     new_workday = {}
 
     hours_worked = 0.0
-    break_hours = 0.0
+    total_duration = 0
     first_checkin = ""
     last_checkout = ""
 
     # not pair of IN/OUT either missing
     if len(employee_checkins)% 2 != 0:
+        hours_worked = -36.0
         employee_checkin_message = ""
         for d in employee_checkins:
             employee_checkin_message += "<li>CheckIn Type:{0} for {1}</li>".format(d.log_type, frappe.get_desk_link("Employee Checkin", d.name))
@@ -351,43 +354,70 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
         for i in range(len(clockin_list)):
             wh = time_diff_in_hours(clockout_list[i],clockin_list[i])
             hours_worked += float(str(wh))
-        
-        # get total break hours
-        for i in range(len(clockout_list)):
-            if ((i+1) < len(clockout_list)):
-                wh = time_diff_in_hours(clockin_list[i+1],clockout_list[i])
-                break_hours += float(str(wh))
 
+        # Calculate difference between first check-in and last checkout
         if clockin_list and clockout_list:
             first_checkin = clockin_list[0]
-            last_checkout = clockout_list[-1] 
+            last_checkout = clockout_list[-1]  # Last element of clockout_list
+            total_duration = time_diff_in_hours(last_checkout, first_checkin) 
 
-    break_minutes = employee_default_work_hour.break_minutes
+        if is_break_from_checkins_with_swapped_hours:
+            total_duration, hours_worked = hours_worked, total_duration
+
+    default_break_minutes = employee_default_work_hour.break_minutes
+    default_break_hours = flt(default_break_minutes / 60)
     target_hours = employee_default_work_hour.hours
 
-    expected_break_hours = flt(break_minutes / 60)
-    break_hours = flt(break_hours)
+    if len(employee_checkins) % 2 == 0:
+        break_from_checkins = 0.0
+        for i in range(len(clockout_list) - 1):
+            wh = time_diff_in_hours(clockin_list[i + 1], clockout_list[i])
+            break_from_checkins += float(wh)
+
+        if hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Employee Checkins":
+            break_hours = break_from_checkins
+
+        elif hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours":
+            break_hours = default_break_hours
+
+        elif hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
+            if break_from_checkins <= default_break_hours:
+                break_hours = default_break_hours
+            else:
+                break_hours = break_from_checkins
+        else:
+            break_hours = 0.0
+
+    else:
+        break_hours = flt(-360.0)
+
     hours_worked = flt(hours_worked)
-    actual_working_hours = hours_worked - expected_break_hours
+
+    if is_break_from_checkins_with_swapped_hours:
+        #swapping for gall
+        if hours_worked > 0:
+            actual_working_hours = hours_worked - break_hours
+        else:
+            actual_working_hours = total_duration - default_break_hours
+
+    else:
+        if total_duration > 0:
+            actual_working_hours = total_duration - break_hours
+        else:    
+            actual_working_hours = hours_worked - default_break_hours
     attendance = employee_checkins[0].attendance if len(employee_checkins) > 0 else ""
     status = frappe.db.get_value("Attendance", attendance, "status") if attendance else ""
 
-    if no_break_hours and hours_worked < 6: # TODO: set 6 as constant
-        break_minutes = 0
-        expected_break_hours = 0
+    if no_break_hours and hours_worked < 6 and not is_break_from_checkins_with_swapped_hours: # TODO: set 6 as constant
+        default_break_minutes = 0
+        #expected_break_hours = 0
         actual_working_hours = hours_worked
-
-    hr_addon_settings = frappe.get_doc("HR Addon Settings")
-    if hr_addon_settings.enable_default_break_hour_for_shorter_breaks:
-        default_break_hours = flt(employee_default_work_hour.break_minutes/60)
-        if break_hours <= default_break_hours:
-            break_hours = flt(default_break_hours)
 
     new_workday.update({
         "target_hours": target_hours,
-        "break_minutes": break_minutes,
+        "break_minutes": default_break_minutes,
         "hours_worked": hours_worked,
-        "expected_break_hours": expected_break_hours,
+        "expected_break_hours": default_break_hours,
         "actual_working_hours": actual_working_hours,
         "nbreak": 0,
         "attendance": attendance,


### PR DESCRIPTION
## Description
To add following fields in HR Addon Settings and functionality related to it on workday controller

* Workday break Calculation Mechanism (Select Field)
* Swap Hours worked and Actual Working Hours (CheckBox)

**Key changes:**
* Added fields in HR Addon Settings
* Modified get_workday to apply logic based on new fields as its working in v14

**Related issue(s)/ticket(s):**
* [GitLab Parent Issue](https://git.phamos.eu/gallehr/gallehr/-/issues/90) 
* [GitLab issue:](https://git.phamos.eu/gallehr/gallehr/-/issues/97) 

**Testing done:**
* Manual Testing

**Screenshot:**

**Checklist:**
* [X] I followed this (guideline)[https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation]
* [X] I created feature branch from develop
* [X] The name of the feature branch follows conventions
* [X] I created logical commit with a clear messages
* [X] I pulled the changes from develop (again) and resolve possible conflicts
* [X] I pushed changes to remote feature branch
* [X] I created a Pull Request with title and description as described in the guideline
* [X] I checked if there is any conflict after creating the PR