### PR TITLE
fix: update to use now_datetime() for current time in scheduled job

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -484,7 +484,7 @@ def generate_workdays_scheduled_job():
 		5:"Saturday",
 		6:"Sunday"
 	}
-	now = frappe.utils.datetime.datetime.now()
+	now = frappe.utils.now_datetime()
 	today_weekday_number = now.weekday()
 	weekday_name = number2name_dict[today_weekday_number]
 	if weekday_name == day:


### PR DESCRIPTION
### PR Description

This PR updates the scheduler job to use `frappe.utils.now_datetime()` instead of `frappe.utils.datetime.datetime.now()`.

Previously, the code was using Python’s `datetime.now()`, which returns a naive datetime based on the server’s system clock. This could lead to issues when the server’s timezone was different from the ERPNext **System Settings → Time Zone**, causing scheduled jobs to run at the wrong hour (e.g., one hour early/late).

By switching to `frappe.utils.now_datetime()`, the job now consistently uses the timezone defined in the site’s settings. This ensures that day and hour comparisons (e.g., `Wednesday at 07:00`) match the expected schedule regardless of server configuration.

**Changes Made:**

* Replaced `frappe.utils.datetime.datetime.now()` with `frappe.utils.now_datetime()`.
* This ensures scheduler time checks are timezone-aware and aligned with system settings.

GITLAB ISSUE: https://git.phamos.eu/suncycle/suncycle/-/work_items/1279
GITLAB PARENT ISSUE: https://git.phamos.eu/suncycle/suncycle/-/issues/806
