### PR TITLE
37 manually setting attendance in workday and updating in employee checkins

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -7,7 +7,8 @@ frappe.ui.form.on('Workday', {
 			return{
 				"filters":[
 					['Attendance','employee','=',frm.doc.employee],
-					['Attendance','attendance_date','=',frm.doc.log_date]
+					['Attendance','attendance_date','=',frm.doc.log_date],
+					['Attendance','docstatus','=',1]
 				]
 			};
 		});
@@ -46,6 +47,27 @@ frappe.ui.form.on('Workday', {
 			}, 1000);
 		} // TODO: consider case of frm.doc.status === "Half Day"
 	},
+
+	attendance: function(frm){
+		if (frm.doc.employee_checkins && frm.doc.attendance){
+			frappe.call({
+				method: "hr_addon.hr_addon.doctype.workday.workday.set_attendance_in_employee_checkins",
+				args: {
+					employee_checkins: frm.doc.employee_checkins,
+					attendance: frm.doc.attendance
+				},
+				callback: function(r){
+					if (r.message == true){
+						frm.save();
+						frappe.show_alert({
+							message:__('Attendance updated in Employee Checkins'),
+							indicator:'green'
+						}, 5);
+					}
+				}
+			})
+		}
+	}
 });
 
 var get_hours = function(frm){

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -325,6 +325,28 @@ def get_actual_employee_log(aemployee, adate):
     return new_workday
 
 
+@frappe.whitelist()
+def set_attendance_in_employee_checkins(employee_checkins, attendance):
+	if isinstance(employee_checkins, str):
+		import json
+		employee_checkins = json.loads(employee_checkins)
+	if not employee_checkins:
+		return
+
+	checkin_updated = False
+	for checkin in employee_checkins:
+		checkin
+		if checkin.get("employee_checkin") is None:
+			continue
+		checkin_doc = frappe.get_doc("Employee Checkin", checkin.get("employee_checkin"))
+		if checkin_doc.attendance == attendance:
+			continue
+		checkin_doc.attendance = attendance
+		checkin_doc.save()
+		checkin_updated = True
+
+	return checkin_updated
+
 def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
     hr_addon_settings = frappe.get_cached_doc("HR Addon Settings")
     is_break_from_checkins_with_swapped_hours = hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Employee Checkins" and hr_addon_settings.swap_hours_worked_and_actual_working_hours


### PR DESCRIPTION
## Description
when selecting attendance record in Workday and saving for, field was cleared again. Attendance link field options were showing cancelled one's as well

**Key changes:**
* Added Attendance docstatus query filter to only show submitted records.
* Create set_attendance_in_employee_checkins API to set/update "Market Attendance" in "Employee Checkins"

**Related issue(s)/ticket(s):**
* GitLab issue [36](https://git.phamos.eu/phamos/hr-department/-/issues/36)
* GitLab issue [1427](https://git.phamos.eu/suncycle/suncycle/-/issues/1427)
* GitLab issue [1428](https://git.phamos.eu/suncycle/suncycle/-/issues/1428)

**Testing done:**
* Manual testing

**Screenshots & GIFs (if applicable):**
[Screencast from 2025-09-15 19-34-13.webm](https://github.com/user-attachments/assets/97eb6032-a8ee-47d4-99b2-6037d465493b)

**Checklist:**
* [X] I followed this (guideline)[https://doku.phamos.eu/books/developer-onboarding/page/pull-request-creation]
* [x] I created feature branch from develop
* [x] The name of the feature branch follows conventions
* [X] I created logical commit with a clear messages
* [x] I pulled the changes from develop (again) and resolve possible conflicts
* [x] I pushed changes to remote feature branch
* [X] I created a Pull Request with title and description as described in the guideline
* [x] I checked if there is any conflict after creating the PR