### PR TITLE
update workday status to half day if leave application is half day

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -57,15 +57,18 @@ class Workday(Document):
 
 		leave_application = frappe.db.exists("Leave Application", filters)
 		if leave_application :
-			self.target_hours = 0
-			self.expected_break_hours= 0
-			self.actual_working_hours= 0
-			self.status = "On Leave"
-
-		if (self.status == 'Half Day'):
-			self.target_hours = self.target_hours / 2
-		elif (self.status == 'On Leave'):
-			self.target_hours = 0
+			half_day = frappe.db.get_value("Leave Application", leave_application, "half_day") 
+			if half_day:
+				self.target_hours = self.target_hours / 2
+				self.expected_break_hours= self.expected_break_hours/2
+				if self.hours_worked == 0: 
+					self.actual_working_hours= -self.target_hours  
+				self.status = "Half Day"
+			else: 
+				self.target_hours = 0
+				self.expected_break_hours= 0
+				self.actual_working_hours= 0
+				self.status = "On Leave"
 
 	def date_is_in_comp_off(self):
 		leave_types = frappe.get_all("Leave Type", filters={"is_compensatory": 1}, pluck="name")


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1848
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/1849
Description : 
if leave application is of type half day then update workday.
status  =  half day 

<img width="1022" height="397" alt="Screenshot 2025-12-16 at 14 20 11" src="https://github.com/user-attachments/assets/8a86e8af-7070-4416-923c-644b98f4eb92" />
<img width="1241" height="646" alt="Screenshot 2025-12-16 at 14 20 22" src="https://github.com/user-attachments/assets/dddb3029-8574-4ba8-9e38-625ae6cf02f0" />
<img width="1225" height="640" alt="Screenshot 2025-12-16 at 14 20 31" src="https://github.com/user-attachments/assets/adaf8f22-68d3-4c80-8339-498586d4c522" />
