### PR TITLE
Fixed the half-day logic

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -57,8 +57,13 @@ class Workday(Document):
 
 		leave_application = frappe.db.exists("Leave Application", filters)
 		if leave_application :
-			half_day = frappe.db.get_value("Leave Application", leave_application, "half_day") 
-			if half_day:
+			half_day, half_day_date = frappe.db.get_value("Leave Application", leave_application, ["half_day", "half_day_date"])
+			
+			# Apply half-day logic only if this specific date is the half day
+			# For single-day leaves, half_day_date is None
+			is_half_day_for_this_date = half_day and (not half_day_date or getdate(half_day_date) == getdate(self.log_date))
+			
+			if is_half_day_for_this_date:
 				self.target_hours = self.target_hours / 2
 				self.expected_break_hours= self.expected_break_hours/2
 				if self.hours_worked == 0: 


### PR DESCRIPTION
Problem: The workday logic was checking only if a leave application had half_day=True, causing all days in a multi-day leave to be treated as half days, even when only one specific date should be.

Solution: Updated set_status_for_leave_application method to fetch both half_day and half_day_date fields, then compare half_day_date with the current workday's date.

Result: Now only the specific date marked as half day receives half-day calculations (e.g., 3.75 hours target), while all other dates in the leave period are correctly treated as full leave days (0 hours target).

Example: For a leave from Jan 8-15 with Jan 15 as half day, only Jan 15 shows "Half Day" status; Jan 8-14 show "On Leave" status.

<img width="857" height="567" alt="Screenshot 2026-01-05 at 14 59 50" src="https://github.com/user-attachments/assets/66a0ddf2-aa19-4805-af6c-d055dd8511ac" />
<img width="688" height="564" alt="Screenshot 2026-01-05 at 14 59 58" src="https://github.com/user-attachments/assets/fb2bc262-2d4a-4a4b-9fa9-e36798057bdf" />
<img width="940" height="430" alt="Screenshot 2026-01-05 at 15 18 47" src="https://github.com/user-attachments/assets/7d63a282-3d84-4b6f-ac9e-95779f0ae711" />
