### PR TITLE
feat:skip workday if no working hours

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -16,6 +16,7 @@
   "time",
   "generate_workdays_for_past_7_days_now",
   "enabled",
+  "skip_workday_if_no_weekly_hours",
   "column_break_jozi",
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
@@ -162,12 +163,19 @@
    "label": "Background Job Frequency",
    "mandatory_depends_on": "eval: doc.enabled",
    "options": "Weekly\nDaily"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, automatic and manual workday generation will skip employees who do not have Weekly Working Hours configured. Only employees with defined Weekly Working Hours will have workdays created.",
+   "fieldname": "skip_workday_if_no_weekly_hours",
+   "fieldtype": "Check",
+   "label": "Skip Workdays for Employees without Weekly Hours"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-15 17:44:47.996847",
+ "modified": "2026-01-13 16:06:46.566155",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -311,7 +311,7 @@ def get_employee_checkin(employee,atime):
     return checkin_list or []
 
 
-def get_employee_default_work_hour(employee, adate):
+def get_employee_default_work_hour(employee, adate, skip_workday_if_no_weekly_hours=None):
     adate = getdate(adate)
     dayname = adate.strftime('%A')
 
@@ -344,8 +344,18 @@ def get_employee_default_work_hour(employee, adate):
 
     target_work_hours = query.run(as_dict=True)
 
+	# If parameter not passed, fetch from settings (for scheduler)
+    if skip_workday_if_no_weekly_hours is None:
+       skip_workday_if_no_weekly_hours = frappe.db.get_single_value(
+            'HR Addon Settings', 
+            'skip_workday_if_no_weekly_hours'
+       ) or 0
+
     if not target_work_hours:
-        frappe.throw(_('Please create Weekly Working Hours for the selected Employee:{0} first for date : {1}.').format(employee,adate))
+        if skip_workday_if_no_weekly_hours:
+           return None  # Skip enabled - return None gracefully
+        else:
+            frappe.throw(_('Please create Weekly Working Hours for the selected Employee:{0} first for date : {1}.').format(employee,adate))
 
     if len(target_work_hours) > 1:
         target_work_hours= "<br> ".join([frappe.get_desk_link("Weekly Working Hours", w.name) for w in target_work_hours])
@@ -355,9 +365,12 @@ def get_employee_default_work_hour(employee, adate):
 
 
 @frappe.whitelist()
-def get_actual_employee_log(aemployee, adate):
+def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=None):
     employee_checkins = get_employee_checkin(aemployee,adate)
-    employee_default_work_hour = get_employee_default_work_hour(aemployee,adate)
+    employee_default_work_hour = get_employee_default_work_hour(aemployee,adate,skip_workday_if_no_weekly_hours)
+    # If None, employee has no weekly hours and skip is enabled
+    if employee_default_work_hour is None:
+       return None
     is_date_in_holiday_list = date_is_in_holiday_list(aemployee,adate)
     no_break_hours = employee_default_work_hour.no_break_hours
     is_target_hours_zero_on_holiday = employee_default_work_hour.set_target_hours_to_zero_when_date_is_holiday
@@ -626,6 +639,9 @@ def generate_workdays_scheduled_job():
 def generate_workdays_for_past_7_days_now():
 	import time
 	start_time = time.time()
+	# Fetch setting value
+	hr_addon_settings = frappe.get_doc("HR Addon Settings")
+	skip_if_no_weekly_hours = getattr(hr_addon_settings, 'skip_workday_if_no_weekly_hours', 0) or 0
 	
 	# Create log document
 	log_doc = frappe.get_doc({
@@ -660,13 +676,21 @@ def generate_workdays_for_past_7_days_now():
 				# if employee_name == "HR-EMP-00001": raise Exception("Test error: Simulating employee-specific failure")
 				
 				unmarked_days = get_unmarked_range(employee_name, a_week_ago.strftime("%Y-%m-%d"), today.strftime("%Y-%m-%d"))
-				valid_unmarked_days = []
-				for date in unmarked_days:
-					if has_valid_weekly_working_hours(employee_name, date):
-						valid_unmarked_days.append(date)
 				
-				if not valid_unmarked_days:
-					continue  # No valid dates, skip
+				if not unmarked_days: 
+					continue  # No unmarked days, skip to next employee 
+
+				if skip_if_no_weekly_hours:
+					# Filter unmarked days to only those with valid weekly working hours 
+					valid_unmarked_days = []
+					for date in unmarked_days:
+						if has_valid_weekly_working_hours(employee_name, date):
+							valid_unmarked_days.append(date)
+				
+					if not valid_unmarked_days:
+						continue  # No valid dates, skip
+				else:
+					valid_unmarked_days = unmarked_days 	
 
 				total_employees += 1
 				total_dates += len(valid_unmarked_days)
@@ -724,7 +748,8 @@ def generate_workdays_for_past_7_days_now():
 				data = {
 					"employee": employee_name,
 					"unmarked_days": valid_unmarked_days,
-					"log_name": log_doc.name  # Pass log name to background job
+					"log_name": log_doc.name,  # Pass log name to background job
+					"skip_workday_if_no_weekly_hours": skip_if_no_weekly_hours
 				}
 				flag = "Create workday"
 
@@ -913,8 +938,15 @@ def bulk_process_workdays(data,flag):
 					})
 				
 				# Get actual employee log data to capture all calculated values
-				workday_data = get_actual_employee_log(emp, date)
-				
+				workday_data = get_actual_employee_log(emp, date, data.get('skip_workday_if_no_weekly_hours'))
+
+				if workday_data is None: 
+					creation_log.status = "Skipped"
+					creation_log.error_message = ("No Weekly Working Hours found and skipping is enabled.")
+					creation_log.insert(ignore_permissions=True)
+					frappe.db.commit()
+					continue  # Skip to next date 
+
 				# Populate calculated values
 				creation_log.hours_worked = workday_data.get("hours_worked", 0)
 				creation_log.break_hours = workday_data.get("break_hours", 0)

--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -16,7 +16,14 @@ frappe.listview_settings['Workday'] = {
 		list_view.page.add_inner_button(__("Process Workdays"), function() {
 			let dialog = new frappe.ui.Dialog({
 				title: __("Process Workdays"),
-				fields: [				{
+				fields: [		
+					{
+					fieldname: 'skip_workday_if_no_weekly_hours',
+					label: __('Skip Workday if No Weekly Working Hours'),
+					fieldtype: 'Check',
+					default: 0
+				},
+					{
 					fieldname: 'employee',
 					label: __('For Employee(s) - Leave empty for all active'),
 					fieldtype: 'MultiSelectList',
@@ -207,8 +214,8 @@ frappe.listview_settings['Workday'] = {
 												} else {
 													employee_names = employee_list.map(emp => `• ${emp}`).join('<br>');
 												}
-												
-												frappe.confirm(
+												if(missing_dates_string != "None") {
+													frappe.confirm(
 													__("Are you sure you want to process workdays for the following {0} employee(s) from {1} to {2}?<br><br><b>Employees:</b><br>{3}<br><br><b>Dates to process:</b><br>{4}", [
 														employee_count,
 														frappe.datetime.str_to_user(data.date_from),
@@ -238,7 +245,10 @@ frappe.listview_settings['Workday'] = {
 													function() {
 														// User cancelled
 													}
-												);
+													);}
+												else{
+													frappe.msgprint(__("No new workdays to process for the selected employee(s) in the given date range.") ); 
+												}	
 											}
 										});
 									}
@@ -250,9 +260,15 @@ frappe.listview_settings['Workday'] = {
 				primary_action_label: __('Process Workdays')
 
 			});
-			dialog.$wrapper.find('.btn-modal-primary').removeClass('btn-primary').addClass('btn-dark');
-			dialog.show();
-		});
+		dialog.$wrapper.find('.btn-modal-primary').removeClass('btn-primary').addClass('btn-dark');
+		dialog.show();
+		
+		// Fetch default value from HR Addon Settings
+		frappe.db.get_single_value('HR Addon Settings', 'skip_workday_if_no_weekly_hours')
+			.then(value => {
+				dialog.set_value('skip_workday_if_no_weekly_hours', value || 0);
+			});
+	});
 		list_view.page.change_inner_button_type('Process Workdays',null, 'dark');
 	},
 	get_day_range_options: function(employee, from_day, to_day) {


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1906
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/1920

Description : 

This pull request introduces a new feature to the HR Addon that allows administrators to skip automatic and manual workday generation for employees who do not have Weekly Working Hours configured. The change is implemented across both the backend (Python) and frontend (JavaScript), ensuring the setting is respected in scheduled jobs, manual processing, and user dialogs. Additionally, the setting is exposed in the HR Addon Settings and the workday processing dialog for easy configuration.

**Feature: Skip Workday Generation for Employees without Weekly Working Hours**

_Backend logic and settings:_
* Added a new checkbox field `skip_workday_if_no_weekly_hours` to `HR Addon Settings`, allowing administrators to enable or disable this behavior. [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R19) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R166-R178)
* Modified workday generation logic (`workday.py`) so that when the skip setting is enabled, employees without Weekly Working Hours are excluded from automatic and manual workday creation. This includes updates to `get_employee_default_work_hour`, `get_actual_employee_log`, and the workday generation functions to respect the setting and handle skipped cases gracefully. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L314-R314) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R347-R357) [[3]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L358-R373) [[4]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R642-R644) [[5]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R679-R693) [[6]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L727-R752) [[7]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L916-R948)

_User interface enhancements:_
* Updated the workday list view dialog (`workday_list.js`) to include a checkbox for the new skip option, which is pre-filled based on the current HR Addon Settings value. [[1]](diffhunk://#diff-7462ba7b39c055e321f902248989cf304a93a16deb7197266e211c97b66cf745L19-R26) [[2]](diffhunk://#diff-7462ba7b39c055e321f902248989cf304a93a16deb7197266e211c97b66cf745R265-R270)
* Improved user feedback in the dialog to show a message when there are no new workdays to process for the selected employees and date range. [[1]](diffhunk://#diff-7462ba7b39c055e321f902248989cf304a93a16deb7197266e211c97b66cf745L210-R217) [[2]](diffhunk://#diff-7462ba7b39c055e321f902248989cf304a93a16deb7197266e211c97b66cf745L241-R251)