### PR TITLE
fix:creating workdays for employees without Weekly Working Hours

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -21,6 +21,12 @@ class Workday(Document):
 
 	def set_actual_employee_log(self):
 		new_workday_dict = get_actual_employee_log(self.employee, self.log_date)
+		if new_workday_dict is None:
+			frappe.throw(_("Cannot create workday for employee {0} on date {1}. Weekly Working Hours not configured. Please configure Weekly Working Hours.").format(
+            self.employee, 
+            frappe.format(self.log_date, {"fieldtype": "Date"})
+        ))
+			
 		self.employee_checkins = []
 
 		self.hours_worked = new_workday_dict.get("hours_worked")


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1906
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/1920

Description : 
This pull request improves error handling in the `workday.py` file by adding a validation check to ensure that "Weekly Working Hours" are configured before creating a workday entry for an employee. If this configuration is missing, a clear and actionable error message is now shown.

Validation and error handling improvements:

* Added a check in the `set_actual_employee_log` method to throw a descriptive error if "Weekly Working Hours" are not configured for the employee, preventing the creation of an invalid workday entry.