### PR TITLE
add summery of workday creation,skip dates for no weekly hours

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -908,9 +908,10 @@ def bulk_process_workdays(data,flag):
 			frappe.throw(_("No unmarked days found for the selected date range"))
 			return
 
-	all_missing_dates = []
+	all_missing_dates = set()
 	skipped_by_employee = {}
 	created_by_employee = {}
+	existing_workdays = {}
 
 	# Process workdays for each employee
 	for emp in employee_list:
@@ -1025,8 +1026,17 @@ def bulk_process_workdays(data,flag):
 					existing_workday = frappe.db.get_value('Workday', 
 						{'employee': emp,'log_date': get_datetime(date)}, 'name')
 					creation_log.workday = existing_workday
+					if existing_workday:
+						if emp not in existing_workdays:
+							emp_name = frappe.get_value('Employee', emp, 'employee_name') 
+							existing_workdays[emp] = {
+								"employee_name": emp_name or emp,
+								"reason": "Already Exists",
+								"dates": []
+							}
+						existing_workdays[emp]["dates"].append(date)
 
-				all_missing_dates.append(get_datetime(date))
+				all_missing_dates.add(get_datetime(date))
 			
 				# Save creation log
 				creation_log.insert(ignore_permissions=True)
@@ -1058,7 +1068,7 @@ def bulk_process_workdays(data,flag):
 					frappe.db.commit()
 
 	formatted_missing_dates = []
-	for missing_date in all_missing_dates:
+	for missing_date in sorted(all_missing_dates):
 		formatted_m_date = formatdate(missing_date,'dd.MM.yyyy')
 		formatted_missing_dates.append(formatted_m_date)
 
@@ -1067,5 +1077,6 @@ def bulk_process_workdays(data,flag):
 		"missing_dates": formatted_missing_dates,
 		"flag":flag,
 		"created_summary": created_by_employee,
-		"skipped_summary": skipped_by_employee 
+		"skipped_summary": skipped_by_employee,
+		"existing_summary": existing_workdays 
 	}

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -180,10 +180,17 @@ def get_unmarked_range(employee, from_day, to_day):
 			employee_list = [employee]
 	else:
 		employee_list = employee if isinstance(employee, list) else [employee]
-	
 	# If only one employee, use the old logic for backward compatibility
 	if len(employee_list) == 1:
 		single_employee = employee_list[0]
+		# weekly hours check
+		work_hours = get_employee_default_work_hour(
+			single_employee,
+			from_day,
+			skip_workday_if_no_weekly_hours=1
+			)
+		if work_hours is None:
+			return []
 		joining_date, relieving_date = frappe.get_cached_value("Employee", single_employee, ["date_of_joining", "relieving_date"])
 		
 		start_day = from_day
@@ -219,6 +226,14 @@ def get_unmarked_range(employee, from_day, to_day):
 	
 	for emp in employee_list:
 		joining_date, relieving_date = frappe.get_cached_value("Employee", emp, ["date_of_joining", "relieving_date"])
+
+		work_hours = get_employee_default_work_hour(
+			emp,
+			from_day,
+			skip_workday_if_no_weekly_hours=1
+		)
+		if work_hours is None:
+			continue
 		
 		start_day = from_day
 		end_day = to_day
@@ -246,6 +261,7 @@ def get_unmarked_range(employee, from_day, to_day):
 				all_unmarked_days.add(date)
 	
 	return sorted(list(all_unmarked_days))
+
 
 
 @frappe.whitelist()
@@ -893,6 +909,8 @@ def bulk_process_workdays(data,flag):
 			return
 
 	all_missing_dates = []
+	skipped_by_employee = {}
+	created_by_employee = {}
 
 	# Process workdays for each employee
 	for emp in employee_list:
@@ -947,6 +965,14 @@ def bulk_process_workdays(data,flag):
 				workday_data = get_actual_employee_log(emp, date, data.get('skip_workday_if_no_weekly_hours'))
 
 				if workday_data is None: 
+					if emp not in skipped_by_employee:
+						emp_name = frappe.get_value('Employee', emp, 'employee_name') 
+						skipped_by_employee[emp] = {
+							"employee_name": emp_name or emp,
+							"reason": "No Weekly Working Hours",
+							"dates": []
+						}
+					skipped_by_employee[emp]["dates"].append(date)
 					creation_log.status = "Skipped"
 					creation_log.error_message = ("No Weekly Working Hours found and skipping is enabled.")
 					creation_log.insert(ignore_permissions=True)
@@ -987,6 +1013,13 @@ def bulk_process_workdays(data,flag):
 					if flag == "Create workday":
 						workday.save()
 						creation_log.workday = workday.name
+						if emp not in created_by_employee:
+							emp_name = frappe.get_value('Employee', emp, 'employee_name') 
+							created_by_employee[emp]={
+								"employee_name": emp_name or emp,
+								"workdays": [] 
+							}
+						created_by_employee[emp]["workdays"].append(workday.name)
 				else:
 					creation_log.status = "Skipped"
 					existing_workday = frappe.db.get_value('Workday', 
@@ -1032,5 +1065,7 @@ def bulk_process_workdays(data,flag):
 	return {
 		"message": 1,
 		"missing_dates": formatted_missing_dates,
-		"flag":flag
+		"flag":flag,
+		"created_summary": created_by_employee,
+		"skipped_summary": skipped_by_employee 
 	}

--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -234,7 +234,9 @@ frappe.listview_settings['Workday'] = {
 																if (r.message && r.message.message === 1) {
 																	const summary = r.message.created_summary || {}; 
 																	const skipped_summary = r.message.skipped_summary || {}; 
+																	const existing_summary = r.message.existing_summary || {}; 
 																	let lines = [];
+																	
 																	Object.keys(summary).forEach(empId => { 
 																		const emp = summary[empId];
 																		if(emp.workdays.length){
@@ -243,6 +245,12 @@ frappe.listview_settings['Workday'] = {
 																		})
 																	Object.keys(skipped_summary).forEach(empId => { 
 																		const emp = skipped_summary[empId];
+																		if(emp.dates.length){
+																			lines.push(`<b>${emp.employee_name} (${empId})</b>: ${emp.reason} (${emp.dates.join(", ")})`
+																		); }
+																		})
+																	Object.keys(existing_summary).forEach(empId => { 
+																		const emp = existing_summary[empId];
 																		if(emp.dates.length){
 																			lines.push(`<b>${emp.employee_name} (${empId})</b>: ${emp.reason} (${emp.dates.join(", ")})`
 																		); }

--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -232,6 +232,33 @@ frappe.listview_settings['Workday'] = {
 															},
 															callback: function(r) {
 																if (r.message && r.message.message === 1) {
+																	const summary = r.message.created_summary || {}; 
+																	const skipped_summary = r.message.skipped_summary || {}; 
+																	let lines = [];
+																	Object.keys(summary).forEach(empId => { 
+																		const emp = summary[empId];
+																		if(emp.workdays.length){
+																			lines.push(`<b>${emp.employee_name} (${empId})</b>: ${emp.workdays.join(", ")}`
+																		); }
+																		})
+																	Object.keys(skipped_summary).forEach(empId => { 
+																		const emp = skipped_summary[empId];
+																		if(emp.dates.length){
+																			lines.push(`<b>${emp.employee_name} (${empId})</b>: ${emp.reason} (${emp.dates.join(", ")})`
+																		); }
+																		})
+																	if(lines.length){
+																		frappe.msgprint(
+																			{
+																				title: __('Workdays Created'), 
+																				message: lines.join("<br>"), 
+																			}
+																		)
+																	}
+																	else{
+																		frappe.msgprint(__("No workdays were created.") ); 
+																	}
+																		
 																	frappe.show_alert({
 																		message: __("Workdays Processed"),
 																		indicator: "blue",


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1906
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/1920

This pull request enhances the handling and reporting of bulk workday creation in the HR module, especially for cases involving multiple employees and various workday statuses. The changes improve both backend processing and frontend feedback, providing clearer summaries of which workdays were created, skipped, or already existed, and the reasons for skipping.

**Backend enhancements for bulk workday processing:**

* Added logic in `get_unmarked_range` to skip employees without weekly working hours, both for single and multiple employees, improving accuracy and preventing unnecessary processing. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L183-R193) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R230-R237)
* Updated `bulk_process_workdays` to track and summarize workdays that were created, skipped (with reasons, e.g., "No Weekly Working Hours"), or already existed for each employee, using structured dictionaries for better reporting. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L895-R914) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R969-R976) [[3]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R1017-R1039)
* Changed the collection of missing dates to a set for uniqueness and sorted the output for consistency. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R1017-R1039) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L1028-R1081)
* The return value of `bulk_process_workdays` now includes detailed summaries for created, skipped, and existing workdays per employee.

**Frontend improvements for user feedback:**

* Enhanced the list view JavaScript (`workday_list.js`) to display a detailed message summarizing created, skipped, and existing workdays by employee after processing, making it easier for users to understand the outcome of their bulk action.