### PR TITLE
format date

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -236,6 +236,8 @@ frappe.listview_settings['Workday'] = {
 																	const skipped_summary = r.message.skipped_summary || {}; 
 																	const existing_summary = r.message.existing_summary || {}; 
 																	let lines = [];
+																	const formatDates = (dates) =>
+    																	dates.map(d => frappe.datetime.str_to_user(d)).join(", ");
 																	
 																	Object.keys(summary).forEach(empId => { 
 																		const emp = summary[empId];
@@ -246,13 +248,13 @@ frappe.listview_settings['Workday'] = {
 																	Object.keys(skipped_summary).forEach(empId => { 
 																		const emp = skipped_summary[empId];
 																		if(emp.dates.length){
-																			lines.push(`<b>${emp.employee_name} (${empId})</b>: ${emp.reason} (${emp.dates.join(", ")})`
+																			lines.push(`<b>${emp.employee_name} (${empId})</b>: ${emp.reason} (${formatDates(emp.dates)})`
 																		); }
 																		})
 																	Object.keys(existing_summary).forEach(empId => { 
 																		const emp = existing_summary[empId];
 																		if(emp.dates.length){
-																			lines.push(`<b>${emp.employee_name} (${empId})</b>: ${emp.reason} (${emp.dates.join(", ")})`
+																			lines.push(`<b>${emp.employee_name} (${empId})</b>: ${emp.reason} (${formatDates(emp.dates)})`
 																		); }
 																		})
 																	if(lines.length){


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1906
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/1920

This pull request improves the display of date information in the `Workday` list view by formatting dates in a more user-friendly way. Specifically, it introduces a helper function to convert date strings to the user's locale format before displaying them in summary lines.

Improvements to date formatting:

* Added a `formatDates` helper function to convert date strings to the user's locale format using `frappe.datetime.str_to_user`.
* Updated the rendering of skipped and existing summary lines to use the new `formatDates` function, ensuring dates are consistently formatted for users.