### PR TITLE
update process workday creation summery

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -280,19 +280,17 @@ frappe.listview_settings['Workday'] = {
 																		blocks.push("<br><b>Existing Workdays:</b><br>" + existingLines.join("<br>"));   
 																	} 
 																		
-																	if(blocks.length){
-
-																		console.log(blocks.join("<br><br>")); 
-																		frappe.msgprint(
-																			{
-																				title: __('Workdays Summary'), 
-																				message: blocks.join("<br><br>"), 
-																			}
-																		)
-																	}
-																	else{
-																		frappe.msgprint(__("No workdays were created.") ); 
-																	}
+																	const summaryMessage = blocks.filter(Boolean).join("<br><br>").trim();
+																	const finalMessage = summaryMessage.length
+																		? summaryMessage
+																		: __("No workdays were created.");
+																	console.log(finalMessage);
+																	frappe.msgprint(
+																		{
+																			title: __('Workdays Summary'),
+																			message: finalMessage,
+																		}
+																	);
 																		
 																	frappe.show_alert({
 																		message: __("Workdays Processed"),


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1906

Problem statement :
In workday_list.js, the Workdays Summary dialog is populated from blocks.join("<br><br>"). blocks is built from createdLines, skippedLines, and existingLines. These arrays are only populated when specific fields (emp.workdays, emp.dates) are non-empty. In some responses, the logs show summary data in the console, but the blocks array resolves to an empty or whitespace-only string, causing frappe.msgprint to render an empty modal body.
Root cause
Console output is not guaranteed to come from the same string used for the dialog.
The dialog uses blocks.join(...), which can be empty or whitespace even when other debug logs show objects or partial data.


Solution:
Create a single finalMessage string used for both logging and display:
Build summaryMessage = blocks.filter(Boolean).join("<br><br>").trim()
If empty, replace with a fallback ("No workdays were created.")
Use finalMessage for both console.log(finalMessage) and frappe.msgprint({ message: finalMessage })
This guarantees the dialog always shows exactly what you log and never renders empty content.