### PR TITLE
show workday summery after end of all server messages

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -284,13 +284,16 @@ frappe.listview_settings['Workday'] = {
 																	const finalMessage = summaryMessage.length
 																		? summaryMessage
 																		: __("No workdays were created.");
-																	console.log(finalMessage);
-																	frappe.msgprint(
-																		{
-																			title: __('Workdays Summary'),
-																			message: finalMessage,
-																		}
-																	);
+																	const showSummary = () => {
+																		console.log(finalMessage);
+																		frappe.msgprint(
+																			{
+																				title: __('Workdays Summary'),
+																				message: finalMessage,
+																			}
+																		);
+																	};
+																	frappe.after_server_call().then(showSummary);
 																		
 																	frappe.show_alert({
 																		message: __("Workdays Processed"),

--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -241,7 +241,7 @@ frappe.listview_settings['Workday'] = {
 																	const summary = r.message.created_summary || {}; 
 																	const skipped_summary = r.message.skipped_summary || {}; 
 																	const existing_summary = r.message.existing_summary || {}; 
-																	console.log(summary, skipped_summary, existing_summary); 
+																	
 
 																	const createdLines = []; 
 																	const skippedLines = []; 
@@ -285,7 +285,6 @@ frappe.listview_settings['Workday'] = {
 																		? summaryMessage
 																		: __("No workdays were created.");
 																	const showSummary = () => {
-																		console.log(finalMessage);
 																		frappe.msgprint(
 																			{
 																				title: __('Workdays Summary'),


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1906

## Problem statement
When processing workdays, the **Workdays Summary dialog appears empty** even though the console shows the summary string. This happens because Frappe’s request cleanup displays `_server_messages` (e.g., Attendance/Overtime messages) and **clears the global msgprint dialog after the summary is shown**, leaving the modal body blank.

## Root cause
`frappe.request.cleanup` calls:

- `frappe.hide_msgprint()`  
- `frappe.msgprint(messages)`  

This runs **after** summary `frappe.msgprint`, so the summary is overwritten or cleared.

## Solution
Display the Workdays Summary **after** the server call has fully completed, so it’s the last msgprint and isn’t cleared by `_server_messages`.

Implementation approach:
- Wrap the summary display in `frappe.after_server_call().then(showSummary)`  
- This ensures any server messages are handled first, and the summary is shown last.