### PR TITLE
Suncycle/suncycle#1906

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -136,7 +136,8 @@ frappe.listview_settings['Workday'] = {
 										filters: {
 											status: 'Active'
 										},
-										fields: ['name']
+										fields: ['name'],
+										limit_page_length: 0 
 									},
 									callback: function(r) {
 										if (r.message && r.message.length > 0) {
@@ -209,7 +210,8 @@ frappe.listview_settings['Workday'] = {
 												filters: {
 													name: ['in', employee_list]
 												},
-												fields: ['name', 'employee_name']
+												fields: ['name', 'employee_name'],
+												limit_page_length: 0 
 											},
 											callback: function(emp_response) {
 												let employee_names = '';


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1906
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/1942

This pull request introduces a minor update to the employee and workday list queries in `workday_list.js`. The main change is the addition of the `limit_page_length: 0` parameter to ensure all relevant records are retrieved without pagination limits.

Query improvements:

* Added `limit_page_length: 0` to the workday query to fetch all active workdays without restricting the number of results. (`hr_addon/hr_addon/doctype/workday/workday_list.js`, [hr_addon/hr_addon/doctype/workday/workday_list.jsL139-R140](diffhunk://#diff-7462ba7b39c055e321f902248989cf304a93a16deb7197266e211c97b66cf745L139-R140))
* Added `limit_page_length: 0` to the employee query to fetch all matching employees without restricting the number of results. (`hr_addon/hr_addon/doctype/workday/workday_list.js`, [hr_addon/hr_addon/doctype/workday/workday_list.jsL212-R214](diffhunk://#diff-7462ba7b39c055e321f902248989cf304a93a16deb7197266e211c97b66cf745L212-R214))