### PR TITLE
on delete of workday , delete workday creation logs

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -113,6 +113,17 @@ class Workday(Document):
 			.format(frappe.get_desk_link("Workday", workday),self.employee, formatdate(self.log_date))
 			)
 	
+	def on_trash(self):
+		logs = frappe.db.get_list("Workday Creation Log", filters={"workday": self.name}, pluck="name")
+		if logs:
+			for log in logs:
+				frappe.delete_doc("Workday Creation Log", log, force=1)
+
+			frappe.msgprint(_("{0} Workday Creation Log(s) deleted successfully.").format(len(logs)),
+				   alert=True,
+				   indicator="green"
+				)
+
 
 def get_month_map():
 	return frappe._dict({

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -116,12 +116,14 @@ class Workday(Document):
 	def on_trash(self):
 		logs = frappe.db.get_list("Workday Creation Log", filters={"workday": self.name}, pluck="name")
 		if logs:
+			log_list = "<br>".join(logs)
 			for log in logs:
 				frappe.delete_doc("Workday Creation Log", log, force=1)
 
-			frappe.msgprint(_("{0} Workday Creation Log(s) deleted successfully.").format(len(logs)),
+			frappe.msgprint(_("{0} Workday Creation Log(s) deleted successfully : <br><br>{1}").format(len(logs),log_list),
 				   alert=True,
-				   indicator="green"
+				   indicator="green",
+				   title=_("Logs Deleted")
 				)
 
 


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1906
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/1955



Description : 
This pull request adds a cleanup operation to the `Workday` DocType to ensure related logs are properly deleted when a workday is removed. The main change is the introduction of an `on_trash` method to handle associated `Workday Creation Log` records.

**Workday deletion cleanup:**

* Added an `on_trash` method to `workday.py` that deletes all `Workday Creation Log` records linked to a `Workday` when it is deleted, and displays a confirmation message to the user.

