### PR TITLE
if no check ins then actual working hours set to 0

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -439,7 +439,7 @@ def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=No
             new_workday = {
                 "target_hours": employee_default_work_hour.hours,
                 "break_minutes": employee_default_work_hour.break_minutes,
-                "actual_working_hours": -employee_default_work_hour.hours,
+                "actual_working_hours": 0,
                 "manual_workday": 1,
                 "hours_worked": 0,
                 "nbreak": 0,


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/1843
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/1997

This pull request makes a small but important adjustment to the calculation of actual working hours for a new workday record. The change ensures that the `actual_working_hours` field is initialized to zero instead of a negative value, which will help prevent errors in downstream calculations.

- Initialize `actual_working_hours` to `0` (was previously set to the negative of default hours) in the `get_actual_employee_log` function in `workday.py`.