### PR TITLE
update actual work hour calculation

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -546,15 +546,19 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
     hours_worked = flt(hours_worked)
 
     if is_break_from_checkins_with_swapped_hours:
-        #swapping for gall
+        # When swap is enabled: hours_worked contains total_duration (after swap at line 517)
+        # and total_duration contains sum of work periods, so use total_duration - break_hours
         if hours_worked > 0:
-            actual_working_hours = hours_worked - break_hours
+            actual_working_hours = total_duration - break_hours
         else:
             actual_working_hours = total_duration - default_break_hours
 
     else:
+        # When swap is disabled: hours_worked contains sum of work periods (excluding breaks)
+        # and total_duration contains time span from first check-in to last checkout (including breaks)
+        # Use hours_worked - break_hours to correctly deduct breaks from actual work periods
         if total_duration > 0:
-            actual_working_hours = total_duration - break_hours
+            actual_working_hours = hours_worked - break_hours
         else:    
             actual_working_hours = hours_worked - default_break_hours
     attendance = employee_checkins[0].attendance if len(employee_checkins) > 0 else ""


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2003
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2004

**When:**

* Workday Break Calculation Mechanism = "Break Hours from Weekly Working Hours" OR "Break Hours from Weekly Working Hours if Shorter Breaks"
* AND swap is disabled (`swap_hours_worked_and_actual_working_hours = 0`)

**Then:**

* `hours_worked` = sum of actual working periods excluding breaks (e.g., 08:00-12:00 = 4h, 13:00-17:00 = 4h → total = 8h)
* `total_duration` = total time span from first check-in to last checkout, including breaks (e.g., 08:00-17:00 = 9h)
* Use `hours_worked - break_hours` to correctly deduct breaks from actual work periods (e.g., 8h - 1h = 7h)

**Result:** Break hours are deducted correctly, giving 7 hours instead of 8 hours in example.

This pull request updates the calculation logic for actual working hours in the `get_workday` function to clarify and correct how break times are deducted, depending on whether the "swap" feature is enabled. The changes improve the accuracy and maintainability of the work hour calculation.

**Work hours calculation improvements:**

* Clarified comments and updated logic to ensure that, when the swap feature is enabled, `actual_working_hours` is calculated as `total_duration - break_hours`, and when disabled, as `hours_worked - break_hours`, providing more accurate deduction of break times in both scenarios.