### PR TITLE
add html txt box to show logic

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -10,6 +10,41 @@ frappe.ui.form.on('HR Addon Settings', {
                 },
             };
         });
+		// Update break calculation logic explanation on form load
+		update_break_calculation_logic(frm);
+		
+		// Listen for theme changes and update the HTML field
+		if (!frm._theme_observer) {
+			frm._theme_observer = new MutationObserver(function(mutations) {
+				mutations.forEach(function(mutation) {
+					if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+						update_break_calculation_logic(frm);
+					}
+				});
+			});
+			frm._theme_observer.observe(document.body, {
+				attributes: true,
+				attributeFilter: ['class']
+			});
+			
+			// Also listen for system theme changes
+			if (window.matchMedia) {
+				frm._theme_media_query = window.matchMedia('(prefers-color-scheme: dark)');
+				frm._theme_media_query.addListener(function() {
+					update_break_calculation_logic(frm);
+				});
+			}
+		}
+	},
+
+	workday_break_calculation_mechanism: function(frm) {
+		// Update break calculation logic explanation when option changes
+		update_break_calculation_logic(frm);
+	},
+
+	swap_hours_worked_and_actual_working_hours: function(frm) {
+		// Update break calculation logic explanation when swap field changes
+		update_break_calculation_logic(frm);
 	},
 
 	validate: function(frm){
@@ -57,4 +92,138 @@ function generateRandomString(length) {
 	}
 	
 	return randomString;
+}
+
+function get_break_calculation_logic_html(mechanism, swapEnabled = false) {
+	// Detect theme (dark or light)
+	const isDarkTheme = document.body.classList.contains('dark-theme') || 
+		(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+	
+	// Theme-aware colors
+	const colors = {
+		light: {
+			bg1: '#e7f3ff',
+			bg2: '#fff3cd',
+			bg3: '#d1ecf1',
+			border1: '#007bff',
+			border2: '#ffc107',
+			border3: '#17a2b8',
+			text: '#333',
+			textSecondary: '#666',
+			heading1: '#007bff',
+			heading2: '#856404',
+			heading3: '#0c5460'
+		},
+		dark: {
+			bg1: 'rgba(0, 123, 255, 0.15)',
+			bg2: 'rgba(255, 193, 7, 0.15)',
+			bg3: 'rgba(23, 162, 184, 0.15)',
+			border1: '#4dabf7',
+			border2: '#ffd43b',
+			border3: '#66d9ef',
+			text: 'var(--text-color)',
+			textSecondary: 'var(--text-muted)',
+			heading1: '#4dabf7',
+			heading2: '#ffd43b',
+			heading3: '#66d9ef'
+		}
+	};
+	
+	const theme = isDarkTheme ? colors.dark : colors.light;
+	
+	const swapInfo = swapEnabled ? `
+			<div style="padding: 12px; background-color: ${isDarkTheme ? 'rgba(255, 193, 7, 0.1)' : '#fff9e6'}; border-left: 3px solid ${theme.border2}; margin-top: 12px; border-radius: 3px;">
+				<p style="margin: 0 0 8px 0; color: ${theme.text}; line-height: 1.6;">
+					<strong style="color: ${theme.heading2};">Swap Hours worked and Actual Working Hours:</strong> Enabled
+				</p>
+				<p style="margin-bottom: 6px; color: ${theme.text}; line-height: 1.6; font-size: 13px;">
+					When swap is enabled, the system swaps the meaning of these fields:
+				</p>
+				<ul style="margin: 6px 0 0 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6; font-size: 13px;">
+					<li><strong>Hours Worked</strong> = Time span from first check-in to last checkout (including breaks)</li>
+					<li><strong>Actual Working Hours</strong> = Sum of work periods (excluding breaks) - Break Hours</li>
+				</ul>
+				<p style="margin: 8px 0 0 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Note:</strong> This is useful when you want "Hours Worked" to represent the total time span at work, and "Actual Working Hours" to represent only productive work time.
+				</p>
+			</div>
+		` : `
+			<div style="padding: 12px; background-color: ${isDarkTheme ? 'rgba(108, 117, 125, 0.1)' : '#f8f9fa'}; border-left: 3px solid ${isDarkTheme ? '#6c757d' : '#6c757d'}; margin-top: 12px; border-radius: 3px;">
+				<p style="margin: 0 0 8px 0; color: ${theme.text}; line-height: 1.6;">
+					<strong>Swap Hours worked and Actual Working Hours:</strong> Disabled
+				</p>
+				<p style="margin-bottom: 6px; color: ${theme.text}; line-height: 1.6; font-size: 13px;">
+					When swap is disabled (default behavior):
+				</p>
+				<ul style="margin: 6px 0 0 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6; font-size: 13px;">
+					<li><strong>Hours Worked</strong> = Sum of work periods (excluding breaks)</li>
+					<li><strong>Actual Working Hours</strong> = Hours Worked - Break Hours</li>
+				</ul>
+			</div>
+		`;
+
+	const logicContent = {
+		"Break Hours from Employee Checkins": `
+			<div style="padding: 15px; background-color: ${theme.bg1}; border-left: 4px solid ${theme.border1}; margin: 10px 0; border-radius: 4px;">
+				<h4 style="margin-top: 0; color: ${theme.heading1}; font-size: 14px; font-weight: 600;">Break Hours from Employee Checkins</h4>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Logic:</strong> Uses the actual break time calculated from time gaps between consecutive checkouts and checkins.
+				</p>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Calculation:</strong> The system sums all time differences between each clockout and the next clockin to determine total break hours.
+				</p>
+				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Example:</strong> If an employee clocks out at 12:00 and clocks in at 13:00, the break time is 1 hour. All such gaps throughout the day are summed.
+				</p>
+				${swapInfo}
+			</div>
+		`,
+		"Break Hours from Weekly Working Hours": `
+			<div style="padding: 15px; background-color: ${theme.bg2}; border-left: 4px solid ${theme.border2}; margin: 10px 0; border-radius: 4px;">
+				<h4 style="margin-top: 0; color: ${theme.heading2}; font-size: 14px; font-weight: 600;">Break Hours from Weekly Working Hours</h4>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Logic:</strong> Uses the predefined break time configured in Weekly Working Hours.
+				</p>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Calculation:</strong> The break hours are taken directly from the Weekly Working Hours configuration (break_minutes converted to hours). This is a fixed value regardless of actual checkin patterns.
+				</p>
+				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Note:</strong> The actual break time from checkins is ignored. The system always uses the configured break time from Weekly Working Hours.
+				</p>
+			</div>
+		`,
+		"Break Hours from Weekly Working Hours if Shorter breaks": `
+			<div style="padding: 15px; background-color: ${theme.bg3}; border-left: 4px solid ${theme.border3}; margin: 10px 0; border-radius: 4px;">
+				<h4 style="margin-top: 0; color: ${theme.heading3}; font-size: 14px; font-weight: 600;">Break Hours from Weekly Working Hours if Shorter breaks</h4>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Logic:</strong> Compares the actual break time from checkins with the default break hours from Weekly Working Hours.
+				</p>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Calculation:</strong>
+					<ul style="margin: 8px 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6;">
+						<li>If actual break from checkins ≤ default break hours: Uses default break hours from Weekly Working Hours</li>
+						<li>If actual break from checkins > default break hours: Uses the actual break time from checkins</li>
+					</ul>
+				</p>
+				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Example:</strong> If default break is 0.5 hours (30 min) but employee took 1 hour break, the system uses 1 hour. If employee took only 0.25 hours break, the system uses 0.5 hours (default).
+				</p>
+			</div>
+		`
+	};
+
+	const defaultMsg = `<div style="padding: 15px; color: ${theme.textSecondary};">Please select a break calculation mechanism to see the logic explanation.</div>`;
+	return logicContent[mechanism] || defaultMsg;
+}
+
+function update_break_calculation_logic(frm) {
+	const mechanism = frm.doc.workday_break_calculation_mechanism;
+	const swapEnabled = mechanism === "Break Hours from Employee Checkins" && frm.doc.swap_hours_worked_and_actual_working_hours;
+	const htmlContent = get_break_calculation_logic_html(mechanism, swapEnabled);
+	
+	// Update the HTML field
+	const htmlField = frm.fields_dict.workday_break_calculation_logic;
+	if (htmlField && htmlField.$wrapper) {
+		htmlField.$wrapper.html(htmlContent);
+	}
 }

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -20,6 +20,7 @@
   "column_break_jozi",
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
+  "workday_break_calculation_logic",
   "notification_section",
   "anniversary_notification_email_list",
   "enable_work_anniversaries_notification",
@@ -170,12 +171,17 @@
    "fieldname": "skip_workday_if_no_weekly_hours",
    "fieldtype": "Check",
    "label": "Skip Workdays for Employees without Weekly Hours"
+  },
+  {
+   "fieldname": "workday_break_calculation_logic",
+   "fieldtype": "HTML",
+   "label": "Break Calculation Logic Explanation"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-13 16:06:46.566155",
+ "modified": "2026-02-13 10:05:35.436360",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2003
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2030

Description  : 

<img width="1274" height="726" alt="Screenshot 2026-02-13 at 10 17 45" src="https://github.com/user-attachments/assets/368a625e-2866-4c41-b560-55d37c44a7c1" />


This pull request enhances the HR Addon Settings form by adding a dynamic, theme-aware explanation for the break calculation logic. The explanation updates automatically based on user selections and system theme (dark/light mode), helping users better understand how break hours are computed in different scenarios.

**User Interface Enhancements:**

- Added a new HTML field `workday_break_calculation_logic` to the settings form to display a detailed, visually styled explanation of the selected break calculation mechanism, including how "swap hours worked and actual working hours" affects the logic. [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R23) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R174-R184)
- Implemented dynamic updates to the explanation field whenever the user changes the break calculation mechanism or the swap option, and whenever the system or app theme changes (light/dark mode), ensuring the information is always accurate and visually consistent.

**Code Additions:**

- Added the functions `get_break_calculation_logic_html` and `update_break_calculation_logic` to generate and update the HTML content for the explanation field, supporting multiple mechanisms and swap states, with theme-aware styling.