### PR TITLE
Suncycle/suncycle#2003 develop

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -587,7 +587,15 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
 
     hours_worked = flt(hours_worked)
 
-    if is_break_from_checkins_with_swapped_hours:
+    if hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
+        # For this mechanism: use total_duration (total presence on site) minus break_hours
+        # total_duration is time from first checkin to last checkout (includes breaks)
+        if total_duration > 0:
+            actual_working_hours = total_duration - break_hours
+        else:
+            actual_working_hours = total_duration - default_break_hours
+
+    elif is_break_from_checkins_with_swapped_hours:
         # When swap is enabled: hours_worked contains total_duration (after swap at line 517)
         # and total_duration contains sum of work periods, so use total_duration - break_hours
         if hours_worked > 0:


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2003
Issue  : https://git.phamos.eu/suncycle/suncycle/-/work_items/2030

Description : 
This pull request updates the logic for calculating workday hours in the `get_workday` function to support a new break calculation mechanism based on HR addon settings. The most important change is the addition of a conditional branch that checks the `workday_break_calculation_mechanism` setting and applies a new calculation method when appropriate.

**Workday calculation logic:**

* Added a new branch in `get_workday` to use "Break Hours from Weekly Working Hours if Shorter breaks" as a calculation mechanism. When this setting is enabled, the function now calculates `actual_working_hours` as the total duration on site minus break hours, using `total_duration - break_hours` if `total_duration` is positive, or `total_duration - default_break_hours` otherwise.