### PR TITLE
cretae workdays on holidays

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -20,7 +20,7 @@
   "column_break_jozi",
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
-  "workday_break_calculation_logic",
+  "allow_workdays_on_holidays",
   "notification_section",
   "anniversary_notification_email_list",
   "enable_work_anniversaries_notification",
@@ -173,15 +173,17 @@
    "label": "Skip Workdays for Employees without Weekly Hours"
   },
   {
-   "fieldname": "workday_break_calculation_logic",
-   "fieldtype": "HTML",
-   "label": "Break Calculation Logic Explanation"
+   "default": "0",
+   "description": "If enabled, a workday will be created on holidays only when check-in data is available. Disable to prevent workday creation on holidays.",
+   "fieldname": "allow_workdays_on_holidays",
+   "fieldtype": "Check",
+   "label": "Allow Workdays on Holidays"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-13 10:05:35.436360",
+ "modified": "2026-03-10 17:40:44.355697",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -17,10 +17,11 @@
   "generate_workdays_for_past_7_days_now",
   "enabled",
   "skip_workday_if_no_weekly_hours",
+  "allow_workdays_on_holidays",
   "column_break_jozi",
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
-  "allow_workdays_on_holidays",
+  "workday_break_calculation_logic",
   "notification_section",
   "anniversary_notification_email_list",
   "enable_work_anniversaries_notification",
@@ -178,12 +179,17 @@
    "fieldname": "allow_workdays_on_holidays",
    "fieldtype": "Check",
    "label": "Allow Workdays on Holidays"
+  },
+  {
+   "fieldname": "workday_break_calculation_logic",
+   "fieldtype": "HTML",
+   "label": "Break Calculation Logic Explanation"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-10 17:40:44.355697",
+ "modified": "2026-03-10 18:01:31.447653",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/workday/workday.js
+++ b/hr_addon/hr_addon/doctype/workday/workday.js
@@ -28,7 +28,7 @@ frappe.ui.form.on('Workday', {
 				},
 				callback: function(r){
 					if (r.message == true){
-						frappe.msgprint("Given Date is Holiday")
+						//frappe.msgprint("Given Date is Holiday")
 						unset_fields(frm);
 					} else {
 						get_hours(frm);

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -702,6 +702,11 @@ def get_employee_attendance(employee,atime):
 
 @frappe.whitelist()
 def date_is_in_holiday_list(employee, date):
+    allow_workdays_on_holidays = frappe.db.get_single_value("HR Addon Settings", "allow_workdays_on_holidays")
+    if allow_workdays_on_holidays:
+        checkins = get_employee_checkin(employee, date)
+        if not checkins:
+            return False  # Do not create workday if no check-in data
     holiday_list = frappe.get_cached_value("Employee", employee, "holiday_list")
     if not holiday_list:
         frappe.msgprint(_("Holiday list not set in {0}").format(employee))


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2100
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2101

Description :

This pull request introduces a new setting to control workday creation on holidays and updates related logic and UI elements to support this feature. The main theme is improving flexibility around workday handling for holidays based on employee check-in data.

**Feature: Holiday Workday Control**

* Added a new checkbox field `allow_workdays_on_holidays` to `hr_addon_settings.json`, allowing admins to specify whether workdays should be created on holidays only if check-in data is available. This replaces the previous `workday_break_calculation_logic` field. [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L23-R23) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L176-R186)
* Updated the backend logic in `workday.py` to respect the new setting: if enabled, workdays are only created for holidays when employee check-ins exist.

**UI Adjustments**

* Commented out the holiday notification message in `workday.js`, aligning the UI feedback with the new workday creation logic.