### PR TITLE
Suncycle/suncycle#2100 sv 15

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -17,6 +17,7 @@
   "generate_workdays_for_past_7_days_now",
   "enabled",
   "skip_workday_if_no_weekly_hours",
+  "allow_workdays_on_holidays",
   "column_break_jozi",
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
@@ -176,12 +177,19 @@
    "fieldname": "workday_break_calculation_logic",
    "fieldtype": "HTML",
    "label": "Break Calculation Logic Explanation"
+  },
+  {
+   "default": "0",
+   "description": "When unchecked, the scheduler and bulk workday generation will not create Workdays for dates that are holidays and have no Employee Checkin records.",
+   "fieldname": "allow_workdays_on_holidays",
+   "fieldtype": "Check",
+   "label": "Allow Workdays on Holidays"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-11 10:40:44.355697",
+ "modified": "2026-03-11 11:10:35.973350",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -180,7 +180,7 @@
   },
   {
    "default": "0",
-   "description": "When unchecked, the scheduler and bulk workday generation will not create Workdays for dates that are holidays and have no Employee Checkin records.",
+   "description": "When unchecked, the scheduler and bulk workday generation will not create Workdays for dates that are holidays, regardless of Employee Checkin records.",
    "fieldname": "allow_workdays_on_holidays",
    "fieldtype": "Check",
    "label": "Allow Workdays on Holidays"
@@ -189,7 +189,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-11 11:10:35.973350",
+ "modified": "2026-03-11 12:19:23.408629",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -34,10 +34,47 @@ class Workday(Document):
 	def set_actual_employee_log(self):
 		new_workday_dict = get_actual_employee_log(self.employee, self.log_date)
 		if new_workday_dict is None:
-			frappe.throw(_("Cannot create workday for employee {0} on date {1}. Weekly Working Hours not configured. Please configure Weekly Working Hours.").format(
-            self.employee, 
-            frappe.format(self.log_date, {"fieldtype": "Date"})
-        ))
+			# Distinguish between settings-based holiday rules and missing weekly hours
+			is_holiday = date_is_in_holiday_list(self.employee, self.log_date)
+			allow_workdays_on_holidays = frappe.db.get_single_value(
+				"HR Addon Settings", "allow_workdays_on_holidays"
+			) or 0
+			employee_checkins = get_employee_checkin(self.employee, self.log_date)
+
+			if is_holiday and not allow_workdays_on_holidays:
+				# Workdays on holidays are globally disabled in settings
+				frappe.throw(
+					_(
+						"Cannot create workday for employee {0} on date {1}. "
+						"Date is a holiday and 'Allow Workdays on Holidays' is disabled in HR Addon Settings."
+					).format(
+						self.employee,
+						frappe.format(self.log_date, {"fieldtype": "Date"}),
+					)
+				)
+			elif is_holiday and allow_workdays_on_holidays and not employee_checkins:
+				# Requirement: even when allowed, holidays require checkins to create workday
+				frappe.throw(
+					_(
+						"Cannot create workday for employee {0} on date {1}. "
+						"Date is a holiday and there are no Employee Checkins; "
+						"workdays on holidays are only created when checkin data exists."
+					).format(
+						self.employee,
+						frappe.format(self.log_date, {"fieldtype": "Date"}),
+					)
+				)
+			else:
+				# Fallback to existing weekly working hours message
+				frappe.throw(
+					_(
+						"Cannot create workday for employee {0} on date {1}. "
+						"Weekly Working Hours not configured. Please configure Weekly Working Hours."
+					).format(
+						self.employee,
+						frappe.format(self.log_date, {"fieldtype": "Date"}),
+					)
+				)
 			
 		self.employee_checkins = []
 
@@ -427,25 +464,49 @@ def get_employee_default_work_hour(employee, adate, skip_workday_if_no_weekly_ho
 
 @frappe.whitelist()
 def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=None):
-    employee_checkins = get_employee_checkin(aemployee,adate)
-    employee_default_work_hour = get_employee_default_work_hour(aemployee,adate,skip_workday_if_no_weekly_hours)
+    employee_checkins = get_employee_checkin(aemployee, adate)
+    employee_default_work_hour = get_employee_default_work_hour(
+        aemployee, adate, skip_workday_if_no_weekly_hours
+    )
     # If None, employee has no weekly hours and skip is enabled
     if employee_default_work_hour is None:
-       return None
-    is_date_in_holiday_list = date_is_in_holiday_list(aemployee,adate)
+        return None
+
+    is_date_in_holiday_list = date_is_in_holiday_list(aemployee, adate)
     no_break_hours = employee_default_work_hour.no_break_hours
-    is_target_hours_zero_on_holiday = employee_default_work_hour.set_target_hours_to_zero_when_date_is_holiday
-    is_holiday_with_zero_target_hours = is_target_hours_zero_on_holiday and is_date_in_holiday_list
+    is_target_hours_zero_on_holiday = (
+        employee_default_work_hour.set_target_hours_to_zero_when_date_is_holiday
+    )
+    is_holiday_with_zero_target_hours = (
+        is_target_hours_zero_on_holiday and is_date_in_holiday_list
+    )
+
+    # Setting: allow or block workdays on holidays
+    allow_workdays_on_holidays = (
+        frappe.db.get_single_value("HR Addon Settings", "allow_workdays_on_holidays")
+        or 0
+    )
+
+    # Requirement:
+    # - If setting is disabled and date is holiday -> never create workday (even with checkins)
+    # - If setting is enabled but there are no checkins on a holiday -> do not create workday
+    if is_date_in_holiday_list:
+        if not allow_workdays_on_holidays:
+            return None
+        if not employee_checkins:
+            return None
 
     if employee_checkins and not is_holiday_with_zero_target_hours:
-        new_workday = get_workday(employee_checkins, employee_default_work_hour, no_break_hours)
+        new_workday = get_workday(
+            employee_checkins, employee_default_work_hour, no_break_hours
+        )
         return new_workday
     else:
         view_employee_attendance = get_employee_attendance(aemployee, adate)
-        
+
         break_minutes = employee_default_work_hour.break_minutes
         expected_break_hours = flt(break_minutes / 60)
-        
+
         if is_holiday_with_zero_target_hours:
             new_workday = {
                 "target_hours": 0,
@@ -453,8 +514,12 @@ def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=No
                 "actual_working_hours": 0,
                 "hours_worked": 0,
                 "nbreak": 0,
-                "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",
-				"status": view_employee_attendance[0].status if len(view_employee_attendance) > 0 else "",
+                "attendance": view_employee_attendance[0].name
+                if len(view_employee_attendance) > 0
+                else "",
+                "status": view_employee_attendance[0].status
+                if len(view_employee_attendance) > 0
+                else "",
                 "break_hours": 0,
                 "employee_checkins": [],
                 "first_checkin": "",
@@ -469,8 +534,12 @@ def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=No
                 "manual_workday": 1,
                 "hours_worked": 0,
                 "nbreak": 0,
-                "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",
-				"status": view_employee_attendance[0].status if len(view_employee_attendance) > 0 else "",
+                "attendance": view_employee_attendance[0].name
+                if len(view_employee_attendance) > 0
+                else "",
+                "status": view_employee_attendance[0].status
+                if len(view_employee_attendance) > 0
+                else "",
                 "break_hours": 0,
                 "employee_checkins": [],
                 "first_checkin": "",
@@ -1076,16 +1145,38 @@ def bulk_process_workdays(data,flag):
 				workday_data = get_actual_employee_log(emp, date, data.get('skip_workday_if_no_weekly_hours'))
 
 				if workday_data is None: 
+					# Distinguish between reasons for skipping
+					is_holiday = date_is_in_holiday_list(emp, date)
+					allow_workdays_on_holidays = frappe.db.get_single_value(
+						"HR Addon Settings", "allow_workdays_on_holidays"
+					) or 0
+					employee_checkins = employee_checkins or get_employee_checkin(emp, date)
+
+					if is_holiday and not allow_workdays_on_holidays:
+						reason = "Workdays on Holidays Disabled"
+						error_message = (
+							"Date is a holiday and 'Allow Workdays on Holidays' is disabled in HR Addon Settings."
+						)
+					elif is_holiday and allow_workdays_on_holidays and not employee_checkins:
+						reason = "Holiday without Checkins"
+						error_message = (
+							"Date is a holiday but there are no Employee Checkins; "
+							"workdays on holidays are only created when checkin data exists."
+						)
+					else:
+						reason = "No Weekly Working Hours"
+						error_message = "No Weekly Working Hours found and skipping is enabled."
+
 					if emp not in skipped_by_employee:
 						emp_name = frappe.get_value('Employee', emp, 'employee_name') 
 						skipped_by_employee[emp] = {
 							"employee_name": emp_name or emp,
-							"reason": "No Weekly Working Hours",
+							"reason": reason,
 							"dates": []
 						}
 					skipped_by_employee[emp]["dates"].append(date)
 					creation_log.status = "Skipped"
-					creation_log.error_message = ("No Weekly Working Hours found and skipping is enabled.")
+					creation_log.error_message = error_message
 					creation_log.insert(ignore_permissions=True)
 					frappe.db.commit()
 					continue  # Skip to next date 


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2100
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2101


Description  : 

This pull request introduces a new HR Addon setting to control whether workdays can be generated for holidays, and updates workday creation logic to respect this setting. The main theme is improving configurability and clarity around workday generation for holidays, including more informative error handling and messaging.

**Configurability: Workdays on Holidays**
* Added a new checkbox field `allow_workdays_on_holidays` to `HR Addon Settings`, allowing administrators to enable or disable workday creation on holidays. [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R20) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R180-R192)

**Workday Creation Logic**
* Updated `set_actual_employee_log` and `get_actual_employee_log` in `workday.py` to check the new setting: if disabled, workdays are not created for holidays; if enabled, workdays are only created for holidays when Employee Checkin records exist. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L37-R77) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L431-R502)

**Bulk Processing & Error Handling**
* Enhanced bulk workday processing to distinguish and log the reason for skipping workday creation—whether due to holidays, missing checkins, or missing weekly hours—providing more specific error messages.

**Code Quality Improvements**
* Refactored conditional formatting for attendance and status fields to improve readability and consistency. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L456-R522) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L472-R542)