### PR TITLE
create workday if checkins are present

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -496,10 +496,13 @@ def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=No
         if not employee_checkins:
             return None
 
-    if employee_checkins and not is_holiday_with_zero_target_hours:
+    if employee_checkins:
         new_workday = get_workday(
             employee_checkins, employee_default_work_hour, no_break_hours
         )
+        if is_holiday_with_zero_target_hours:
+            new_workday["target_hours"] = 0
+            new_workday["expected_break_hours"] = 0
         return new_workday
     else:
         view_employee_attendance = get_employee_attendance(aemployee, adate)


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2100
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2151

Description :

This pull request introduces an important fix to the logic for calculating employee workdays, specifically handling cases where a holiday has zero target hours. The change ensures that, even if check-ins exist on such holidays, the `target_hours` and `expected_break_hours` are correctly set to zero.

**Workday calculation logic improvements:**

* In `workday.py`, updated the logic in `get_actual_employee_log` to always process employee check-ins, but if the day is a holiday with zero target hours, explicitly set `target_hours` and `expected_break_hours` to zero in the returned `new_workday` dictionary.

