### PR TITLE
added child table

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -10,6 +10,41 @@ frappe.ui.form.on('HR Addon Settings', {
                 },
             };
         });
+		// Update break calculation logic explanation on form load
+		update_break_calculation_logic(frm);
+		
+		// Listen for theme changes and update the HTML field
+		if (!frm._theme_observer) {
+			frm._theme_observer = new MutationObserver(function(mutations) {
+				mutations.forEach(function(mutation) {
+					if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+						update_break_calculation_logic(frm);
+					}
+				});
+			});
+			frm._theme_observer.observe(document.body, {
+				attributes: true,
+				attributeFilter: ['class']
+			});
+			
+			// Also listen for system theme changes
+			if (window.matchMedia) {
+				frm._theme_media_query = window.matchMedia('(prefers-color-scheme: dark)');
+				frm._theme_media_query.addListener(function() {
+					update_break_calculation_logic(frm);
+				});
+			}
+		}
+	},
+
+	workday_break_calculation_mechanism: function(frm) {
+		// Update break calculation logic explanation when option changes
+		update_break_calculation_logic(frm);
+	},
+
+	swap_hours_worked_and_actual_working_hours: function(frm) {
+		// Update break calculation logic explanation when swap field changes
+		update_break_calculation_logic(frm);
 	},
 
 	validate: function(frm){
@@ -57,4 +92,138 @@ function generateRandomString(length) {
 	}
 	
 	return randomString;
+}
+
+function get_break_calculation_logic_html(mechanism, swapEnabled = false) {
+	// Detect theme (dark or light)
+	const isDarkTheme = document.body.classList.contains('dark-theme') || 
+		(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+	
+	// Theme-aware colors
+	const colors = {
+		light: {
+			bg1: '#e7f3ff',
+			bg2: '#fff3cd',
+			bg3: '#d1ecf1',
+			border1: '#007bff',
+			border2: '#ffc107',
+			border3: '#17a2b8',
+			text: '#333',
+			textSecondary: '#666',
+			heading1: '#007bff',
+			heading2: '#856404',
+			heading3: '#0c5460'
+		},
+		dark: {
+			bg1: 'rgba(0, 123, 255, 0.15)',
+			bg2: 'rgba(255, 193, 7, 0.15)',
+			bg3: 'rgba(23, 162, 184, 0.15)',
+			border1: '#4dabf7',
+			border2: '#ffd43b',
+			border3: '#66d9ef',
+			text: 'var(--text-color)',
+			textSecondary: 'var(--text-muted)',
+			heading1: '#4dabf7',
+			heading2: '#ffd43b',
+			heading3: '#66d9ef'
+		}
+	};
+	
+	const theme = isDarkTheme ? colors.dark : colors.light;
+	
+	const swapInfo = swapEnabled ? `
+			<div style="padding: 12px; background-color: ${isDarkTheme ? 'rgba(255, 193, 7, 0.1)' : '#fff9e6'}; border-left: 3px solid ${theme.border2}; margin-top: 12px; border-radius: 3px;">
+				<p style="margin: 0 0 8px 0; color: ${theme.text}; line-height: 1.6;">
+					<strong style="color: ${theme.heading2};">Swap Hours worked and Actual Working Hours:</strong> Enabled
+				</p>
+				<p style="margin-bottom: 6px; color: ${theme.text}; line-height: 1.6; font-size: 13px;">
+					When swap is enabled, the system swaps the meaning of these fields:
+				</p>
+				<ul style="margin: 6px 0 0 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6; font-size: 13px;">
+					<li><strong>Hours Worked</strong> = Time span from first check-in to last checkout (including breaks)</li>
+					<li><strong>Actual Working Hours</strong> = Sum of work periods (excluding breaks) - Break Hours</li>
+				</ul>
+				<p style="margin: 8px 0 0 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Note:</strong> This is useful when you want "Hours Worked" to represent the total time span at work, and "Actual Working Hours" to represent only productive work time.
+				</p>
+			</div>
+		` : `
+			<div style="padding: 12px; background-color: ${isDarkTheme ? 'rgba(108, 117, 125, 0.1)' : '#f8f9fa'}; border-left: 3px solid ${isDarkTheme ? '#6c757d' : '#6c757d'}; margin-top: 12px; border-radius: 3px;">
+				<p style="margin: 0 0 8px 0; color: ${theme.text}; line-height: 1.6;">
+					<strong>Swap Hours worked and Actual Working Hours:</strong> Disabled
+				</p>
+				<p style="margin-bottom: 6px; color: ${theme.text}; line-height: 1.6; font-size: 13px;">
+					When swap is disabled (default behavior):
+				</p>
+				<ul style="margin: 6px 0 0 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6; font-size: 13px;">
+					<li><strong>Hours Worked</strong> = Sum of work periods (excluding breaks)</li>
+					<li><strong>Actual Working Hours</strong> = Hours Worked - Break Hours</li>
+				</ul>
+			</div>
+		`;
+
+	const logicContent = {
+		"Break Hours from Employee Checkins": `
+			<div style="padding: 15px; background-color: ${theme.bg1}; border-left: 4px solid ${theme.border1}; margin: 10px 0; border-radius: 4px;">
+				<h4 style="margin-top: 0; color: ${theme.heading1}; font-size: 14px; font-weight: 600;">Break Hours from Employee Checkins</h4>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Logic:</strong> Uses the actual break time calculated from time gaps between consecutive checkouts and checkins.
+				</p>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Calculation:</strong> The system sums all time differences between each clockout and the next clockin to determine total break hours.
+				</p>
+				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Example:</strong> If an employee clocks out at 12:00 and clocks in at 13:00, the break time is 1 hour. All such gaps throughout the day are summed.
+				</p>
+				${swapInfo}
+			</div>
+		`,
+		"Break Hours from Weekly Working Hours": `
+			<div style="padding: 15px; background-color: ${theme.bg2}; border-left: 4px solid ${theme.border2}; margin: 10px 0; border-radius: 4px;">
+				<h4 style="margin-top: 0; color: ${theme.heading2}; font-size: 14px; font-weight: 600;">Break Hours from Weekly Working Hours</h4>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Logic:</strong> Uses the predefined break time configured in Weekly Working Hours.
+				</p>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Calculation:</strong> The break hours are taken directly from the Weekly Working Hours configuration (break_minutes converted to hours). This is a fixed value regardless of actual checkin patterns.
+				</p>
+				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Note:</strong> The actual break time from checkins is ignored. The system always uses the configured break time from Weekly Working Hours.
+				</p>
+			</div>
+		`,
+		"Break Hours from Weekly Working Hours if Shorter breaks": `
+			<div style="padding: 15px; background-color: ${theme.bg3}; border-left: 4px solid ${theme.border3}; margin: 10px 0; border-radius: 4px;">
+				<h4 style="margin-top: 0; color: ${theme.heading3}; font-size: 14px; font-weight: 600;">Break Hours from Weekly Working Hours if Shorter breaks</h4>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Logic:</strong> Compares the actual break time from checkins with the default break hours from Weekly Working Hours.
+				</p>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Calculation:</strong>
+					<ul style="margin: 8px 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6;">
+						<li>If actual break from checkins ≤ default break hours: Uses default break hours from Weekly Working Hours</li>
+						<li>If actual break from checkins > default break hours: Uses the actual break time from checkins</li>
+					</ul>
+				</p>
+				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Example:</strong> If default break is 0.5 hours (30 min) but employee took 1 hour break, the system uses 1 hour. If employee took only 0.25 hours break, the system uses 0.5 hours (default).
+				</p>
+			</div>
+		`
+	};
+
+	const defaultMsg = `<div style="padding: 15px; color: ${theme.textSecondary};">Please select a break calculation mechanism to see the logic explanation.</div>`;
+	return logicContent[mechanism] || defaultMsg;
+}
+
+function update_break_calculation_logic(frm) {
+	const mechanism = frm.doc.workday_break_calculation_mechanism;
+	const swapEnabled = mechanism === "Break Hours from Employee Checkins" && frm.doc.swap_hours_worked_and_actual_working_hours;
+	const htmlContent = get_break_calculation_logic_html(mechanism, swapEnabled);
+	
+	// Update the HTML field
+	const htmlField = frm.fields_dict.workday_break_calculation_logic;
+	if (htmlField && htmlField.$wrapper) {
+		htmlField.$wrapper.html(htmlContent);
+	}
 }

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -17,6 +17,7 @@
   "generate_workdays_for_past_7_days_now",
   "enabled",
   "skip_workday_if_no_weekly_hours",
+  "allow_workdays_on_holidays",
   "column_break_jozi",
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
@@ -176,12 +177,19 @@
    "fieldname": "workday_break_calculation_logic",
    "fieldtype": "HTML",
    "label": "Break Calculation Logic Explanation"
+  },
+  {
+   "default": "0",
+   "description": "When unchecked, the scheduler and bulk workday generation will not create Workdays for dates that are holidays and have no Employee Checkin records.",
+   "fieldname": "allow_workdays_on_holidays",
+   "fieldtype": "Check",
+   "label": "Allow Workdays on Holidays"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-13 10:05:35.436360",
+ "modified": "2026-03-11 11:10:35.973350",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -20,6 +20,7 @@
   "column_break_jozi",
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
+  "workday_break_calculation_logic",
   "notification_section",
   "anniversary_notification_email_list",
   "enable_work_anniversaries_notification",
@@ -170,12 +171,17 @@
    "fieldname": "skip_workday_if_no_weekly_hours",
    "fieldtype": "Check",
    "label": "Skip Workdays for Employees without Weekly Hours"
+  },
+  {
+   "fieldname": "workday_break_calculation_logic",
+   "fieldtype": "HTML",
+   "label": "Break Calculation Logic Explanation"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-13 16:06:46.566155",
+ "modified": "2026-02-13 10:05:35.436360",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -180,7 +180,7 @@
   },
   {
    "default": "0",
-   "description": "When unchecked, the scheduler and bulk workday generation will not create Workdays for dates that are holidays and have no Employee Checkin records.",
+   "description": "When unchecked, the scheduler and bulk workday generation will not create Workdays for dates that are holidays, regardless of Employee Checkin records.",
    "fieldname": "allow_workdays_on_holidays",
    "fieldtype": "Check",
    "label": "Allow Workdays on Holidays"
@@ -189,7 +189,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-11 11:10:35.973350",
+ "modified": "2026-03-11 12:19:23.408629",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -180,7 +180,7 @@
   },
   {
    "default": "0",
-   "description": "When unchecked, the scheduler and bulk workday generation will not create Workdays for dates that are holidays, regardless of Employee Checkin records.",
+   "description": "Controls how Employee Checkins are processed on holidays only. Unchecked: checkins are ignored and the Workday stays Not Workday. Checked: checkins are evaluated like a normal day (Present / overtime as configured). Without checkins, holidays are Not Workday in both cases.",
    "fieldname": "allow_workdays_on_holidays",
    "fieldtype": "Check",
    "label": "Allow Workdays on Holidays"

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -28,7 +28,9 @@
   "column_break_dvlg",
   "anniversary_notification_email_recipient_role",
   "notification_x_days_before",
-  "enable_work_anniversaries_notification_for_leave_approvers"
+  "enable_work_anniversaries_notification_for_leave_approvers",
+  "break_rules_arbzg_tab",
+  "minimum_break_rule"
  ],
  "fields": [
   {
@@ -184,12 +186,23 @@
    "fieldname": "allow_workdays_on_holidays",
    "fieldtype": "Check",
    "label": "Allow Workdays on Holidays"
+  },
+  {
+   "fieldname": "break_rules_arbzg_tab",
+   "fieldtype": "Tab Break",
+   "label": "Break Rules (ArbZG)"
+  },
+  {
+   "fieldname": "minimum_break_rule",
+   "fieldtype": "Table",
+   "label": "Minimum Break Rule",
+   "options": "Minimum Break Rule"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-11 12:19:23.408629",
+ "modified": "2026-04-30 13:04:22.332475",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -192,8 +192,8 @@ def get_work_anniversary_reminder_text_and_message(anniversary_persons, joining_
     if len(anniversary_persons) == 1:
         anniversary_person = anniversary_persons[0]["name"]
         persons_name = anniversary_person
-        # Number of years completed at the company
-        completed_years = getdate().year - anniversary_persons[0]["date_of_joining"].year
+        # Number of years completed at the company (use anniversary date's year for advance notifications)
+        completed_years = getdate(joining_date).year - anniversary_persons[0]["date_of_joining"].year
         anniversary_person += f" {completed} {get_pluralized_years(completed_years)}"
     else:
         person_names_with_years = []
@@ -201,8 +201,8 @@ def get_work_anniversary_reminder_text_and_message(anniversary_persons, joining_
         for person in anniversary_persons:
             person_text = person["name"]
             names.append(person_text)
-            # Number of years completed at the company
-            completed_years = getdate().year - person["date_of_joining"].year
+            # Number of years completed at the company (use anniversary date's year for advance notifications)
+            completed_years = getdate(joining_date).year - person["date_of_joining"].year
             person_text += f" {completed} {get_pluralized_years(completed_years)}"
             person_names_with_years.append(person_text)
 

--- a/hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.json
+++ b/hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.json
@@ -1,0 +1,48 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-04-30 12:59:02.042541",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "from_hours",
+  "to_hours",
+  "minimum_break_minutes"
+ ],
+ "fields": [
+  {
+   "fieldname": "from_hours",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "From Hours"
+  },
+  {
+   "fieldname": "to_hours",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "To Hours"
+  },
+  {
+   "fieldname": "minimum_break_minutes",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Minimum Break Minutes"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-30 13:04:51.533303",
+ "modified_by": "Administrator",
+ "module": "HR Addon",
+ "name": "Minimum Break Rule",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.py
+++ b/hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class MinimumBreakRule(Document):
+	pass

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -23,12 +23,12 @@ class Workday(Document):
 		"""Show a concise message after creating a Workday, indicating its status."""
 		if self.status == "Missing Checkin":
 			frappe.msgprint(
-			_("Workday created for Employee {0} on {1} with status: {2}").format(
-				self.employee,
-				formatdate(self.log_date),
-				self.status or _("Not Set"),
-			),
-			alert=True,
+				_("Workday created for Employee {0} on {1} with status: {2}").format(
+					self.employee,
+					formatdate(self.log_date),
+					self.status or _("Not Set"),
+				),
+				alert=True,
 			)
 
 	def set_actual_employee_log(self):
@@ -74,7 +74,7 @@ class Workday(Document):
 			filters["leave_type"] = ['not in', leave_types]
 
 		leave_application = frappe.db.exists("Leave Application", filters)
-		if leave_application :
+		if leave_application:
 			half_day, half_day_date = frappe.db.get_value("Leave Application", leave_application, ["half_day", "half_day_date"])
 			
 			# Apply half-day logic only if this specific date is the half day
@@ -83,14 +83,14 @@ class Workday(Document):
 			
 			if is_half_day_for_this_date:
 				self.target_hours = self.target_hours / 2
-				self.expected_break_hours= self.expected_break_hours/2
-				if self.hours_worked == 0: 
-					self.actual_working_hours= -self.target_hours  
+				self.expected_break_hours = self.expected_break_hours / 2
+				if self.hours_worked == 0:
+					self.actual_working_hours = -self.target_hours
 				self.status = "Half Day"
-			else: 
+			else:
 				self.target_hours = 0
-				self.expected_break_hours= 0
-				self.actual_working_hours= 0
+				self.expected_break_hours = 0
+				self.actual_working_hours = 0
 				self.status = "On Leave"
 
 	def date_is_in_comp_off(self):
@@ -192,6 +192,32 @@ def get_unmarked_days(employee, month, exclude_holidays=0):
 	return unmarked_days
 
 
+def _cap_date_range_by_employee_dates(joining_date, relieving_date, from_day, to_day):
+	"""
+	Cap the date range by employee's joining and relieving dates.
+	
+	Args:
+		joining_date: Employee's date of joining (or None)
+		relieving_date: Employee's relieving date (or None)
+		from_day: Start date of the range
+		to_day: End date of the range
+		
+	Returns:
+		tuple: (start_day, end_day) - the capped date range
+	"""
+	start_day = from_day
+	end_day = to_day
+	
+	if joining_date and joining_date >= getdate(from_day):
+		start_day = joining_date
+	# If employee has a relieving date earlier than the selected "to" date,
+	# cap the range at the relieving date; otherwise do not extend beyond "to_day".
+	if relieving_date and relieving_date <= getdate(to_day):
+		end_day = relieving_date
+	
+	return start_day, end_day
+
+
 @frappe.whitelist()
 def get_unmarked_range(employee, from_day, to_day):
 	import json
@@ -218,15 +244,7 @@ def get_unmarked_range(employee, from_day, to_day):
 			return []
 		joining_date, relieving_date = frappe.get_cached_value("Employee", single_employee, ["date_of_joining", "relieving_date"])
 		
-		start_day = from_day
-		end_day = to_day
-
-		if joining_date and joining_date >= getdate(from_day):
-			start_day = joining_date
-		# If employee has a relieving date earlier than the selected "to" date,
-		# cap the range at the relieving date; otherwise do not extend beyond "to_day".
-		if relieving_date and relieving_date <= getdate(to_day):
-			end_day = relieving_date
+		start_day, end_day = _cap_date_range_by_employee_dates(joining_date, relieving_date, from_day, to_day)
 
 		delta = date_diff(end_day, start_day)	
 		days_of_list = ['{}'.format(add_days(start_day,i)) for i in range(delta + 1)]	
@@ -262,15 +280,7 @@ def get_unmarked_range(employee, from_day, to_day):
 		if work_hours is None:
 			continue
 		
-		start_day = from_day
-		end_day = to_day
-
-		if joining_date and joining_date >= getdate(from_day):
-			start_day = joining_date
-		# If employee has a relieving date earlier than the selected "to" date,
-		# cap the range at the relieving date; otherwise do not extend beyond "to_day".
-		if relieving_date and relieving_date <= getdate(to_day):
-			end_day = relieving_date
+		start_day, end_day = _cap_date_range_by_employee_dates(joining_date, relieving_date, from_day, to_day)
 
 		delta = date_diff(end_day, start_day)	
 		days_of_list = ['{}'.format(add_days(start_day,i)) for i in range(delta + 1)]	

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -587,7 +587,15 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
 
     hours_worked = flt(hours_worked)
 
-    if is_break_from_checkins_with_swapped_hours:
+    if hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
+        # For this mechanism: use total_duration (total presence on site) minus break_hours
+        # total_duration is time from first checkin to last checkout (includes breaks)
+        if total_duration > 0:
+            actual_working_hours = total_duration - break_hours
+        else:
+            actual_working_hours = total_duration - default_break_hours
+
+    elif is_break_from_checkins_with_swapped_hours:
         # When swap is enabled: hours_worked contains total_duration (after swap at line 517)
         # and total_duration contains sum of work periods, so use total_duration - break_hours
         if hours_worked > 0:

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -561,8 +561,8 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
         attendance = employee_checkins[0].attendance if len(employee_checkins) > 0 else ""
 
         if employee_checkins:
-            first_checkin = employee_checkins[0].time
-            last_checkout = employee_checkins[-1].time
+            first_checkin = get_datetime(employee_checkins[0].time)
+            last_checkout = get_datetime(employee_checkins[-1].time)
 
         hours_worked = 0.0
         break_hours = 0.0

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -496,10 +496,13 @@ def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=No
         if not employee_checkins:
             return None
 
-    if employee_checkins and not is_holiday_with_zero_target_hours:
+    if employee_checkins:
         new_workday = get_workday(
             employee_checkins, employee_default_work_hour, no_break_hours
         )
+        if is_holiday_with_zero_target_hours:
+            new_workday["target_hours"] = 0
+            new_workday["expected_break_hours"] = 0
         return new_workday
     else:
         view_employee_attendance = get_employee_attendance(aemployee, adate)

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -34,10 +34,47 @@ class Workday(Document):
 	def set_actual_employee_log(self):
 		new_workday_dict = get_actual_employee_log(self.employee, self.log_date)
 		if new_workday_dict is None:
-			frappe.throw(_("Cannot create workday for employee {0} on date {1}. Weekly Working Hours not configured. Please configure Weekly Working Hours.").format(
-            self.employee, 
-            frappe.format(self.log_date, {"fieldtype": "Date"})
-        ))
+			# Distinguish between settings-based holiday rules and missing weekly hours
+			is_holiday = date_is_in_holiday_list(self.employee, self.log_date)
+			allow_workdays_on_holidays = frappe.db.get_single_value(
+				"HR Addon Settings", "allow_workdays_on_holidays"
+			) or 0
+			employee_checkins = get_employee_checkin(self.employee, self.log_date)
+
+			if is_holiday and not allow_workdays_on_holidays:
+				# Workdays on holidays are globally disabled in settings
+				frappe.throw(
+					_(
+						"Cannot create workday for employee {0} on date {1}. "
+						"Date is a holiday and 'Allow Workdays on Holidays' is disabled in HR Addon Settings."
+					).format(
+						self.employee,
+						frappe.format(self.log_date, {"fieldtype": "Date"}),
+					)
+				)
+			elif is_holiday and allow_workdays_on_holidays and not employee_checkins:
+				# Requirement: even when allowed, holidays require checkins to create workday
+				frappe.throw(
+					_(
+						"Cannot create workday for employee {0} on date {1}. "
+						"Date is a holiday and there are no Employee Checkins; "
+						"workdays on holidays are only created when checkin data exists."
+					).format(
+						self.employee,
+						frappe.format(self.log_date, {"fieldtype": "Date"}),
+					)
+				)
+			else:
+				# Fallback to existing weekly working hours message
+				frappe.throw(
+					_(
+						"Cannot create workday for employee {0} on date {1}. "
+						"Weekly Working Hours not configured. Please configure Weekly Working Hours."
+					).format(
+						self.employee,
+						frappe.format(self.log_date, {"fieldtype": "Date"}),
+					)
+				)
 			
 		self.employee_checkins = []
 
@@ -427,25 +464,49 @@ def get_employee_default_work_hour(employee, adate, skip_workday_if_no_weekly_ho
 
 @frappe.whitelist()
 def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=None):
-    employee_checkins = get_employee_checkin(aemployee,adate)
-    employee_default_work_hour = get_employee_default_work_hour(aemployee,adate,skip_workday_if_no_weekly_hours)
+    employee_checkins = get_employee_checkin(aemployee, adate)
+    employee_default_work_hour = get_employee_default_work_hour(
+        aemployee, adate, skip_workday_if_no_weekly_hours
+    )
     # If None, employee has no weekly hours and skip is enabled
     if employee_default_work_hour is None:
-       return None
-    is_date_in_holiday_list = date_is_in_holiday_list(aemployee,adate)
+        return None
+
+    is_date_in_holiday_list = date_is_in_holiday_list(aemployee, adate)
     no_break_hours = employee_default_work_hour.no_break_hours
-    is_target_hours_zero_on_holiday = employee_default_work_hour.set_target_hours_to_zero_when_date_is_holiday
-    is_holiday_with_zero_target_hours = is_target_hours_zero_on_holiday and is_date_in_holiday_list
+    is_target_hours_zero_on_holiday = (
+        employee_default_work_hour.set_target_hours_to_zero_when_date_is_holiday
+    )
+    is_holiday_with_zero_target_hours = (
+        is_target_hours_zero_on_holiday and is_date_in_holiday_list
+    )
+
+    # Setting: allow or block workdays on holidays
+    allow_workdays_on_holidays = (
+        frappe.db.get_single_value("HR Addon Settings", "allow_workdays_on_holidays")
+        or 0
+    )
+
+    # Requirement:
+    # - If setting is disabled and date is holiday -> never create workday (even with checkins)
+    # - If setting is enabled but there are no checkins on a holiday -> do not create workday
+    if is_date_in_holiday_list:
+        if not allow_workdays_on_holidays:
+            return None
+        if not employee_checkins:
+            return None
 
     if employee_checkins and not is_holiday_with_zero_target_hours:
-        new_workday = get_workday(employee_checkins, employee_default_work_hour, no_break_hours)
+        new_workday = get_workday(
+            employee_checkins, employee_default_work_hour, no_break_hours
+        )
         return new_workday
     else:
         view_employee_attendance = get_employee_attendance(aemployee, adate)
-        
+
         break_minutes = employee_default_work_hour.break_minutes
         expected_break_hours = flt(break_minutes / 60)
-        
+
         if is_holiday_with_zero_target_hours:
             new_workday = {
                 "target_hours": 0,
@@ -453,8 +514,12 @@ def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=No
                 "actual_working_hours": 0,
                 "hours_worked": 0,
                 "nbreak": 0,
-                "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",
-				"status": view_employee_attendance[0].status if len(view_employee_attendance) > 0 else "",
+                "attendance": view_employee_attendance[0].name
+                if len(view_employee_attendance) > 0
+                else "",
+                "status": view_employee_attendance[0].status
+                if len(view_employee_attendance) > 0
+                else "",
                 "break_hours": 0,
                 "employee_checkins": [],
                 "first_checkin": "",
@@ -469,8 +534,12 @@ def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=No
                 "manual_workday": 1,
                 "hours_worked": 0,
                 "nbreak": 0,
-                "attendance": view_employee_attendance[0].name if len(view_employee_attendance) > 0 else "",
-				"status": view_employee_attendance[0].status if len(view_employee_attendance) > 0 else "",
+                "attendance": view_employee_attendance[0].name
+                if len(view_employee_attendance) > 0
+                else "",
+                "status": view_employee_attendance[0].status
+                if len(view_employee_attendance) > 0
+                else "",
                 "break_hours": 0,
                 "employee_checkins": [],
                 "first_checkin": "",
@@ -1076,16 +1145,38 @@ def bulk_process_workdays(data,flag):
 				workday_data = get_actual_employee_log(emp, date, data.get('skip_workday_if_no_weekly_hours'))
 
 				if workday_data is None: 
+					# Distinguish between reasons for skipping
+					is_holiday = date_is_in_holiday_list(emp, date)
+					allow_workdays_on_holidays = frappe.db.get_single_value(
+						"HR Addon Settings", "allow_workdays_on_holidays"
+					) or 0
+					employee_checkins = employee_checkins or get_employee_checkin(emp, date)
+
+					if is_holiday and not allow_workdays_on_holidays:
+						reason = "Workdays on Holidays Disabled"
+						error_message = (
+							"Date is a holiday and 'Allow Workdays on Holidays' is disabled in HR Addon Settings."
+						)
+					elif is_holiday and allow_workdays_on_holidays and not employee_checkins:
+						reason = "Holiday without Checkins"
+						error_message = (
+							"Date is a holiday but there are no Employee Checkins; "
+							"workdays on holidays are only created when checkin data exists."
+						)
+					else:
+						reason = "No Weekly Working Hours"
+						error_message = "No Weekly Working Hours found and skipping is enabled."
+
 					if emp not in skipped_by_employee:
 						emp_name = frappe.get_value('Employee', emp, 'employee_name') 
 						skipped_by_employee[emp] = {
 							"employee_name": emp_name or emp,
-							"reason": "No Weekly Working Hours",
+							"reason": reason,
 							"dates": []
 						}
 					skipped_by_employee[emp]["dates"].append(date)
 					creation_log.status = "Skipped"
-					creation_log.error_message = ("No Weekly Working Hours found and skipping is enabled.")
+					creation_log.error_message = error_message
 					creation_log.insert(ignore_permissions=True)
 					frappe.db.commit()
 					continue  # Skip to next date 

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -19,6 +19,18 @@ class Workday(Document):
 		self.validate_duplicate_workday()
 		self.set_status_for_leave_application()
 
+	def after_insert(self):
+		"""Show a concise message after creating a Workday, indicating its status."""
+		if self.status == "Missing Checkin":
+			frappe.msgprint(
+			_("Workday created for Employee {0} on {1} with status: {2}").format(
+				self.employee,
+				formatdate(self.log_date),
+				self.status or _("Not Set"),
+			),
+			alert=True,
+			)
+
 	def set_actual_employee_log(self):
 		new_workday_dict = get_actual_employee_log(self.employee, self.log_date)
 		if new_workday_dict is None:
@@ -211,7 +223,9 @@ def get_unmarked_range(employee, from_day, to_day):
 
 		if joining_date and joining_date >= getdate(from_day):
 			start_day = joining_date
-		if relieving_date and relieving_date >= getdate(to_day):
+		# If employee has a relieving date earlier than the selected "to" date,
+		# cap the range at the relieving date; otherwise do not extend beyond "to_day".
+		if relieving_date and relieving_date <= getdate(to_day):
 			end_day = relieving_date
 
 		delta = date_diff(end_day, start_day)	
@@ -253,7 +267,9 @@ def get_unmarked_range(employee, from_day, to_day):
 
 		if joining_date and joining_date >= getdate(from_day):
 			start_day = joining_date
-		if relieving_date and relieving_date >= getdate(to_day):
+		# If employee has a relieving date earlier than the selected "to" date,
+		# cap the range at the relieving date; otherwise do not extend beyond "to_day".
+		if relieving_date and relieving_date <= getdate(to_day):
 			end_day = relieving_date
 
 		delta = date_diff(end_day, start_day)	
@@ -487,40 +503,30 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
     first_checkin = ""
     last_checkout = ""
 
-    # not pair of IN/OUT either missing
-    if len(employee_checkins)% 2 != 0:
-        hours_worked = -36.0
-        employee_checkin_message = ""
-        for d in employee_checkins:
-            employee_checkin_message += "<li>CheckIn Type:{0} for {1}</li>".format(d.log_type, frappe.get_desk_link("Employee Checkin", d.name))
+    default_break_minutes = employee_default_work_hour.break_minutes
+    default_break_hours = flt(default_break_minutes / 60)
+    target_hours = employee_default_work_hour.hours
 
-        frappe.msgprint("CheckIns must be in pair for the given date:<ul>{}</ul>".format(employee_checkin_message))
-        return new_workday
-
-    if (len(employee_checkins) % 2 == 0):
+    if len(employee_checkins) % 2 == 0:
+        # Even number of checkins – normal calculation flow
         # seperate 'IN' from 'OUT'
-        clockin_list = [get_datetime(kin.time) for x,kin in enumerate(employee_checkins) if x % 2 == 0]
-        clockout_list = [get_datetime(kout.time) for x,kout in enumerate(employee_checkins) if x % 2 != 0]
+        clockin_list = [get_datetime(kin.time) for x, kin in enumerate(employee_checkins) if x % 2 == 0]
+        clockout_list = [get_datetime(kout.time) for x, kout in enumerate(employee_checkins) if x % 2 != 0]
 
         # get total worked hours
         for i in range(len(clockin_list)):
-            wh = time_diff_in_hours(clockout_list[i],clockin_list[i])
+            wh = time_diff_in_hours(clockout_list[i], clockin_list[i])
             hours_worked += float(str(wh))
 
         # Calculate difference between first check-in and last checkout
         if clockin_list and clockout_list:
             first_checkin = clockin_list[0]
             last_checkout = clockout_list[-1]  # Last element of clockout_list
-            total_duration = time_diff_in_hours(last_checkout, first_checkin) 
+            total_duration = time_diff_in_hours(last_checkout, first_checkin)
 
         if is_break_from_checkins_with_swapped_hours:
             total_duration, hours_worked = hours_worked, total_duration
 
-    default_break_minutes = employee_default_work_hour.break_minutes
-    default_break_hours = flt(default_break_minutes / 60)
-    target_hours = employee_default_work_hour.hours
-
-    if len(employee_checkins) % 2 == 0:
         break_from_checkins = 0.0
         for i in range(len(clockout_list) - 1):
             wh = time_diff_in_hours(clockin_list[i + 1], clockout_list[i])
@@ -541,7 +547,33 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
             break_hours = 0.0
 
     else:
-        break_hours = flt(-360.0)
+        # Odd number of checkins – create Workday with status "Missing Checkin"
+        attendance = employee_checkins[0].attendance if len(employee_checkins) > 0 else ""
+
+        if employee_checkins:
+            first_checkin = employee_checkins[0].time
+            last_checkout = employee_checkins[-1].time
+
+        hours_worked = 0.0
+        break_hours = 0.0
+        actual_working_hours = 0.0
+
+        new_workday.update({
+            "target_hours": target_hours,
+            "break_minutes": default_break_minutes,
+            "hours_worked": hours_worked,
+            "expected_break_hours": default_break_hours,
+            "actual_working_hours": actual_working_hours,
+            "nbreak": 0,
+            "attendance": attendance,
+            "status": "Missing Checkin",
+            "break_hours": break_hours,
+            "first_checkin": first_checkin,
+            "last_checkout": last_checkout,
+            "employee_checkins": employee_checkins,
+        })
+
+        return new_workday
 
     hours_worked = flt(hours_worked)
 

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -503,6 +503,66 @@ def set_attendance_in_employee_checkins(employee_checkins, attendance):
 
 	return checkin_updated
 
+@frappe.whitelist()
+def calculate_actual_working_hours(hours_worked, break_hours, default_break_hours, mechanism=None, total_duration=None, is_swapped=None, no_break_hours=False, hours_worked_threshold=6):
+	"""
+	Calculate actual_working_hours based on HR Addon Settings mechanism.
+	Can be called directly from web forms or other whitelisted contexts.
+	
+	Args:
+		hours_worked: Sum of work periods (excluding breaks)
+		break_hours: Calculated break hours
+		default_break_hours: Default break hours from Weekly Working Hours
+		mechanism: Break calculation mechanism from HR Addon Settings (optional, will fetch if not provided)
+		total_duration: Total time from first checkin to last checkout (optional, for Workday)
+		is_swapped: Whether hours_worked and total_duration are swapped (optional, will fetch if not provided)
+		no_break_hours: Whether no break hours setting is enabled
+		hours_worked_threshold: Threshold for no_break_hours check (default 6)
+	
+	Returns:
+		actual_working_hours: Calculated actual working hours
+	"""
+	hours_worked = flt(hours_worked)
+	break_hours = flt(break_hours)
+	default_break_hours = flt(default_break_hours)
+	
+	# Fetch HR Addon Settings if mechanism or is_swapped not provided
+	if mechanism is None or is_swapped is None:
+		hr_addon_settings = frappe.get_cached_doc("HR Addon Settings")
+		if mechanism is None:
+			mechanism = hr_addon_settings.workday_break_calculation_mechanism
+		if is_swapped is None:
+			is_swapped = mechanism == "Break Hours from Employee Checkins" and hr_addon_settings.swap_hours_worked_and_actual_working_hours
+	
+	# Special case: no break hours when hours worked is less than threshold
+	if no_break_hours and hours_worked < hours_worked_threshold and not is_swapped:
+		return hours_worked
+	
+	# Calculate based on mechanism
+	if mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
+		# For this mechanism: use total_duration (total presence on site) minus break_hours
+		if total_duration is not None and total_duration > 0:
+			return flt(total_duration - break_hours)
+		else:
+			# Fallback: use hours_worked - break_hours if total_duration not available
+			return flt(hours_worked - break_hours)
+	
+	elif is_swapped:
+		# When swap is enabled: hours_worked contains total_duration
+		if total_duration is not None and total_duration > 0:
+			return flt(total_duration - break_hours)
+		elif hours_worked > 0:
+			return flt(hours_worked - break_hours)
+		else:
+			return flt(total_duration - default_break_hours) if total_duration is not None else flt(hours_worked - default_break_hours)
+	
+	else:
+		# Default: hours_worked contains sum of work periods (excluding breaks)
+		if total_duration is not None and total_duration > 0:
+			return flt(hours_worked - break_hours)
+		else:
+			return flt(hours_worked - default_break_hours)
+
 def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
     hr_addon_settings = frappe.get_cached_doc("HR Addon Settings")
     is_break_from_checkins_with_swapped_hours = hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Employee Checkins" and hr_addon_settings.swap_hours_worked_and_actual_working_hours
@@ -587,37 +647,20 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
 
     hours_worked = flt(hours_worked)
 
-    if hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
-        # For this mechanism: use total_duration (total presence on site) minus break_hours
-        # total_duration is time from first checkin to last checkout (includes breaks)
-        if total_duration > 0:
-            actual_working_hours = total_duration - break_hours
-        else:
-            actual_working_hours = total_duration - default_break_hours
-
-    elif is_break_from_checkins_with_swapped_hours:
-        # When swap is enabled: hours_worked contains total_duration (after swap at line 517)
-        # and total_duration contains sum of work periods, so use total_duration - break_hours
-        if hours_worked > 0:
-            actual_working_hours = total_duration - break_hours
-        else:
-            actual_working_hours = total_duration - default_break_hours
-
-    else:
-        # When swap is disabled: hours_worked contains sum of work periods (excluding breaks)
-        # and total_duration contains time span from first check-in to last checkout (including breaks)
-        # Use hours_worked - break_hours to correctly deduct breaks from actual work periods
-        if total_duration > 0:
-            actual_working_hours = hours_worked - break_hours
-        else:    
-            actual_working_hours = hours_worked - default_break_hours
+    # Calculate actual_working_hours using shared function
+    actual_working_hours = calculate_actual_working_hours(
+        hours_worked=hours_worked,
+        break_hours=break_hours,
+        default_break_hours=default_break_hours,
+        mechanism=hr_addon_settings.workday_break_calculation_mechanism,
+        total_duration=total_duration,
+        is_swapped=is_break_from_checkins_with_swapped_hours,
+        no_break_hours=no_break_hours,
+        hours_worked_threshold=6
+    )
+    
     attendance = employee_checkins[0].attendance if len(employee_checkins) > 0 else ""
     status = frappe.db.get_value("Attendance", attendance, "status") if attendance else ""
-
-    if no_break_hours and hours_worked < 6 and not is_break_from_checkins_with_swapped_hours: # TODO: set 6 as constant
-        default_break_minutes = 0
-        #expected_break_hours = 0
-        actual_working_hours = hours_worked
 
     new_workday.update({
         "target_hours": target_hours,

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -34,48 +34,16 @@ class Workday(Document):
 	def set_actual_employee_log(self):
 		new_workday_dict = get_actual_employee_log(self.employee, self.log_date)
 		if new_workday_dict is None:
-			# Distinguish between settings-based holiday rules and missing weekly hours
-			is_holiday = date_is_in_holiday_list(self.employee, self.log_date)
-			allow_workdays_on_holidays = frappe.db.get_single_value(
-				"HR Addon Settings", "allow_workdays_on_holidays"
-			) or 0
-			employee_checkins = get_employee_checkin(self.employee, self.log_date)
+			frappe.throw(
+				_(
+					"Cannot create workday for employee {0} on date {1}. "
+					"Weekly Working Hours not configured. Please configure Weekly Working Hours."
+				).format(
+					self.employee,
+					frappe.format(self.log_date, {"fieldtype": "Date"}),
+				)
+			)
 
-			if is_holiday and not allow_workdays_on_holidays:
-				# Workdays on holidays are globally disabled in settings
-				frappe.throw(
-					_(
-						"Cannot create workday for employee {0} on date {1}. "
-						"Date is a holiday and 'Allow Workdays on Holidays' is disabled in HR Addon Settings."
-					).format(
-						self.employee,
-						frappe.format(self.log_date, {"fieldtype": "Date"}),
-					)
-				)
-			elif is_holiday and allow_workdays_on_holidays and not employee_checkins:
-				# Requirement: even when allowed, holidays require checkins to create workday
-				frappe.throw(
-					_(
-						"Cannot create workday for employee {0} on date {1}. "
-						"Date is a holiday and there are no Employee Checkins; "
-						"workdays on holidays are only created when checkin data exists."
-					).format(
-						self.employee,
-						frappe.format(self.log_date, {"fieldtype": "Date"}),
-					)
-				)
-			else:
-				# Fallback to existing weekly working hours message
-				frappe.throw(
-					_(
-						"Cannot create workday for employee {0} on date {1}. "
-						"Weekly Working Hours not configured. Please configure Weekly Working Hours."
-					).format(
-						self.employee,
-						frappe.format(self.log_date, {"fieldtype": "Date"}),
-					)
-				)
-			
 		self.employee_checkins = []
 
 		self.hours_worked = new_workday_dict.get("hours_worked")
@@ -462,6 +430,59 @@ def get_employee_default_work_hour(employee, adate, skip_workday_if_no_weekly_ho
     return target_work_hours[0]
 
 
+def get_holiday_not_workday_log(aemployee, adate, employee_default_work_hour):
+    """
+    Workday row for a holiday when no checkin data is applied (scheduler or manual).
+    Status is always Not Workday; target hours follow Weekly Working Hours holiday rules.
+    """
+    view_employee_attendance = get_employee_attendance(aemployee, adate)
+    break_minutes = employee_default_work_hour.break_minutes
+    expected_break_hours = flt(break_minutes / 60)
+    is_date_in_holiday_list = date_is_in_holiday_list(aemployee, adate)
+    is_target_hours_zero_on_holiday = (
+        employee_default_work_hour.set_target_hours_to_zero_when_date_is_holiday
+    )
+    is_holiday_with_zero_target_hours = (
+        is_target_hours_zero_on_holiday and is_date_in_holiday_list
+    )
+
+    if is_holiday_with_zero_target_hours:
+        return {
+            "target_hours": 0,
+            "break_minutes": employee_default_work_hour.break_minutes,
+            "actual_working_hours": 0,
+            "hours_worked": 0,
+            "nbreak": 0,
+            "attendance": view_employee_attendance[0].name
+            if len(view_employee_attendance) > 0
+            else "",
+            "status": "Not Workday",
+            "break_hours": 0,
+            "employee_checkins": [],
+            "first_checkin": "",
+            "last_checkout": "",
+            "expected_break_hours": 0,
+        }
+
+    return {
+        "target_hours": employee_default_work_hour.hours,
+        "break_minutes": employee_default_work_hour.break_minutes,
+        "actual_working_hours": 0,
+        "manual_workday": 1,
+        "hours_worked": 0,
+        "nbreak": 0,
+        "attendance": view_employee_attendance[0].name
+        if len(view_employee_attendance) > 0
+        else "",
+        "status": "Not Workday",
+        "break_hours": 0,
+        "employee_checkins": [],
+        "first_checkin": "",
+        "last_checkout": "",
+        "expected_break_hours": expected_break_hours,
+    }
+
+
 @frappe.whitelist()
 def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=None):
     employee_checkins = get_employee_checkin(aemployee, adate)
@@ -481,20 +502,25 @@ def get_actual_employee_log(aemployee, adate, skip_workday_if_no_weekly_hours=No
         is_target_hours_zero_on_holiday and is_date_in_holiday_list
     )
 
-    # Setting: allow or block workdays on holidays
+    # allow_workdays_on_holidays only changes whether checkin data is processed on holidays.
+    # Holidays without processed checkins always yield Not Workday (see get_holiday_not_workday_log).
     allow_workdays_on_holidays = (
         frappe.db.get_single_value("HR Addon Settings", "allow_workdays_on_holidays")
         or 0
     )
 
-    # Requirement:
-    # - If setting is disabled and date is holiday -> never create workday (even with checkins)
-    # - If setting is enabled but there are no checkins on a holiday -> do not create workday
     if is_date_in_holiday_list:
         if not allow_workdays_on_holidays:
-            return None
-        if not employee_checkins:
-            return None
+            return get_holiday_not_workday_log(aemployee, adate, employee_default_work_hour)
+        if employee_checkins:
+            new_workday = get_workday(
+                employee_checkins, employee_default_work_hour, no_break_hours
+            )
+            if is_holiday_with_zero_target_hours:
+                new_workday["target_hours"] = 0
+                new_workday["expected_break_hours"] = 0
+            return new_workday
+        return get_holiday_not_workday_log(aemployee, adate, employee_default_work_hour)
 
     if employee_checkins:
         new_workday = get_workday(
@@ -1147,28 +1173,9 @@ def bulk_process_workdays(data,flag):
 				# Get actual employee log data to capture all calculated values
 				workday_data = get_actual_employee_log(emp, date, data.get('skip_workday_if_no_weekly_hours'))
 
-				if workday_data is None: 
-					# Distinguish between reasons for skipping
-					is_holiday = date_is_in_holiday_list(emp, date)
-					allow_workdays_on_holidays = frappe.db.get_single_value(
-						"HR Addon Settings", "allow_workdays_on_holidays"
-					) or 0
-					employee_checkins = employee_checkins or get_employee_checkin(emp, date)
-
-					if is_holiday and not allow_workdays_on_holidays:
-						reason = "Workdays on Holidays Disabled"
-						error_message = (
-							"Date is a holiday and 'Allow Workdays on Holidays' is disabled in HR Addon Settings."
-						)
-					elif is_holiday and allow_workdays_on_holidays and not employee_checkins:
-						reason = "Holiday without Checkins"
-						error_message = (
-							"Date is a holiday but there are no Employee Checkins; "
-							"workdays on holidays are only created when checkin data exists."
-						)
-					else:
-						reason = "No Weekly Working Hours"
-						error_message = "No Weekly Working Hours found and skipping is enabled."
+				if workday_data is None:
+					reason = "No Weekly Working Hours"
+					error_message = "No Weekly Working Hours found and skipping is enabled."
 
 					if emp not in skipped_by_employee:
 						emp_name = frappe.get_value('Employee', emp, 'employee_name') 

--- a/hr_addon/hr_addon/doctype/workday/workday_list.js
+++ b/hr_addon/hr_addon/doctype/workday/workday_list.js
@@ -7,6 +7,8 @@ frappe.listview_settings['Workday'] = {
 			return [__(doc.status), "red", "status,=," + doc.status];
 		} else if (doc.status == "Half Day") {
 			return [__(doc.status), "orange", "status,=," + doc.status];
+		}else if (doc.status == "Missing Checkin"){
+			return [__(doc.status), "orange", "status,=," + doc.status];
 		}
 	},
 


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2158
issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2220

Description  : 
This pull request introduces a new feature to manage minimum break rules in the HR Addon. It adds a new child DocType for defining break intervals and integrates this into the HR Addon Settings, allowing administrators to configure minimum break requirements according to working hours.

**Minimum Break Rules Feature:**

* Added new DocType `Minimum Break Rule` with fields for specifying break requirements based on working hours (`from_hours`, `to_hours`, `minimum_break_minutes`).
* Implemented the corresponding Python class `MinimumBreakRule` to support the new DocType.

**Integration with HR Addon Settings:**

* Updated `hr_addon_settings.json` to include a new tab "Break Rules (ArbZG)" and a table field for managing minimum break rules within the HR Addon Settings UI. [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L31-R33) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R189-R205)