### PR TITLE
Suncycle/suncycle#2158 v15 suncycle 1

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -29,7 +29,7 @@
   "anniversary_notification_email_recipient_role",
   "notification_x_days_before",
   "enable_work_anniversaries_notification_for_leave_approvers",
-  "break_rules_arbzg_tab",
+  "break_rules_tab",
   "minimum_break_rule"
  ],
  "fields": [
@@ -188,21 +188,21 @@
    "label": "Allow Workdays on Holidays"
   },
   {
-   "fieldname": "break_rules_arbzg_tab",
-   "fieldtype": "Tab Break",
-   "label": "Break Rules (ArbZG)"
-  },
-  {
    "fieldname": "minimum_break_rule",
    "fieldtype": "Table",
    "label": "Minimum Break Rule",
    "options": "Minimum Break Rule"
+  },
+  {
+   "fieldname": "break_rules_tab",
+   "fieldtype": "Tab Break",
+   "label": "Break Minutes Rules"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-30 13:04:22.332475",
+ "modified": "2026-04-30 15:26:01.229153",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -28,7 +28,9 @@
   "column_break_dvlg",
   "anniversary_notification_email_recipient_role",
   "notification_x_days_before",
-  "enable_work_anniversaries_notification_for_leave_approvers"
+  "enable_work_anniversaries_notification_for_leave_approvers",
+  "break_rules_arbzg_tab",
+  "minimum_break_rule"
  ],
  "fields": [
   {
@@ -184,12 +186,23 @@
    "fieldname": "allow_workdays_on_holidays",
    "fieldtype": "Check",
    "label": "Allow Workdays on Holidays"
+  },
+  {
+   "fieldname": "break_rules_arbzg_tab",
+   "fieldtype": "Tab Break",
+   "label": "Break Rules (ArbZG)"
+  },
+  {
+   "fieldname": "minimum_break_rule",
+   "fieldtype": "Table",
+   "label": "Minimum Break Rule",
+   "options": "Minimum Break Rule"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-11 12:19:23.408629",
+ "modified": "2026-04-30 13:04:22.332475",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -6,7 +6,7 @@ import frappe, os
 from frappe.model.document import Document
 from frappe import _
 from frappe.utils.data import date_diff
-from frappe.utils import getdate, today, comma_sep, date_diff
+from frappe.utils import getdate, today, comma_sep, date_diff, flt
 from frappe.core.doctype.role.role import get_info_based_on_role
 from frappe.query_builder import DocType
 from icalendar import Event, Calendar
@@ -28,6 +28,42 @@ class HRAddonSettings(Document):
 	
 	def validate(self):
 		self.create_background_job_if_not_exists()
+		self.validate_minimum_break_rules()
+     
+	def validate_minimum_break_rules(self):
+		rules = sorted(
+			(self.minimum_break_rule or []),
+			key=lambda row: (flt(row.from_hours or 0), flt(row.to_hours or 0)),
+		)
+
+		if not rules:
+			return
+
+		prev_to = None
+		for index, row in enumerate(rules, start=1):
+			from_hours = flt(row.from_hours)
+			to_hours = flt(row.to_hours)
+
+			if from_hours < 0 or to_hours < 0:
+				frappe.throw(_("Row {0}: Hours cannot be negative.").format(index))
+
+			if to_hours <= from_hours:
+				frappe.throw(
+					_("Row {0}: To Hours must be greater than From Hours.").format(index)
+				)
+
+			if index == 1 and from_hours != 0:
+				frappe.throw(_("Row 1: The first rule must start from 0 hours."))
+
+			if prev_to is not None and from_hours < prev_to:
+				frappe.throw(
+					_(
+						"Row {0}: Rule overlaps with the previous range. "
+						"Example of invalid overlap: 0-6 and 3-5."
+					).format(index)
+				)
+
+			prev_to = to_hours
 
 	def create_background_job_if_not_exists(self):
 		create_background_job_for_workday_generation(self)

--- a/hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.json
+++ b/hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.json
@@ -1,0 +1,48 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-04-30 12:59:02.042541",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "from_hours",
+  "to_hours",
+  "minimum_break_minutes"
+ ],
+ "fields": [
+  {
+   "fieldname": "from_hours",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "From Hours"
+  },
+  {
+   "fieldname": "to_hours",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "To Hours"
+  },
+  {
+   "fieldname": "minimum_break_minutes",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Minimum Break Minutes"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-30 13:04:51.533303",
+ "modified_by": "Administrator",
+ "module": "HR Addon",
+ "name": "Minimum Break Rule",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.py
+++ b/hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class MinimumBreakRule(Document):
+	pass

--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.json
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.json
@@ -128,13 +128,13 @@
    "options": "Company"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "no_break_hours",
    "fieldtype": "Check",
    "label": "No break hours if target hours is less than 6 hours"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "set_target_hours_to_zero_when_date_is_holiday",
    "fieldtype": "Check",
    "label": "Set Target Hours to Zero when date is holiday"
@@ -142,7 +142,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-25 16:28:30.306002",
+ "modified": "2026-05-04 14:00:16.715749",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Weekly Working Hours",
@@ -174,6 +174,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import getdate
+from frappe.utils import getdate, flt, cint
 from frappe.model.naming import make_autoname
 from frappe import _
 
@@ -25,6 +25,41 @@ class WeeklyWorkingHours(Document):
 	def validate(self):
 		self.validate_if_employee_is_active()
 		self.validate_overlapping_records_in_specific_interval()
+		self.set_break_hours_if_not_set()
+
+	def set_break_hours_if_not_set(self):
+		if not self.hours:
+			return
+
+		settings = frappe.get_single("HR Addon Settings")
+		rules = sorted(
+			(settings.minimum_break_rule or []),
+			key=lambda row: (flt(row.from_hours or 0), flt(row.to_hours or 0)),
+		)
+		if not rules:
+			return
+
+		for hour_row in self.hours:
+			target_hours = flt(hour_row.hours)
+			current_break_minutes = cint(hour_row.break_minutes or 0)
+			if target_hours <= 0 or current_break_minutes != 0:
+				continue
+
+			matched_rule = None
+			for rule in rules:
+				from_hours = flt(rule.from_hours or 0)
+				to_hours = flt(rule.to_hours or 0)
+
+				# Boundaries are inclusive for the first range start (0),
+				# and then open on the left / closed on the right:
+				# 0-6 means <= 6, 6-9 means > 6 and <= 9.
+				in_lower_bound = target_hours >= from_hours if from_hours == 0 else target_hours > from_hours
+				if in_lower_bound and target_hours <= to_hours:
+					matched_rule = rule
+					break
+
+			if matched_rule:
+				hour_row.break_minutes = cint(matched_rule.minimum_break_minutes or 0)
 
 	def validate_if_employee_is_active(self):
 		if self.employee and frappe.get_value('Employee', self.employee, 'status') != "Active":


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2158
issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2220

Description :

This pull request introduces a new feature to manage minimum break rules in the HR Addon. The main changes include the addition of a new child DocType for defining break rules, and updates to the HR Addon Settings to allow configuration of these rules through a new tab and table.

**Minimum Break Rule management:**

* Added a new child DocType `Minimum Break Rule` with fields for `from_hours`, `to_hours`, and `minimum_break_minutes` to specify break requirements for various work durations. (`hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.json` [hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.jsonR1-R48](diffhunk://#diff-5e6582a382d4dafb216d53183513f8b58a48d9db26fdecb1d5cd4d739010d5bfR1-R48))
* Implemented a corresponding Python class `MinimumBreakRule` for the new DocType. (`hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.py` [hr_addon/hr_addon/doctype/minimum_break_rule/minimum_break_rule.pyR1-R9](diffhunk://#diff-8af351b55ed22b09c7c2785582efb6f5062d66aaa3aac01a19e3171de3c183d7R1-R9))

**HR Addon Settings enhancements:**

* Added a new tab (`break_rules_arbzg_tab`) and a table field (`minimum_break_rule`) to the `HR Addon Settings` DocType, enabling configuration and display of minimum break rules in the settings UI. (`hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json` [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L31-R33) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R189-R205)

These changes lay the groundwork for managing and enforcing minimum break requirements in compliance with regulations.