### PR TITLE
fetch break hours in weekly working hours

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -11,6 +11,7 @@ from frappe.core.doctype.role.role import get_info_based_on_role
 from frappe.query_builder import DocType
 from icalendar import Event, Calendar
 from hr_addon.hr_addon.doctype.workday.workday import create_background_job_for_workday_generation
+from math import inf
 
 
 class HRAddonSettings(Document):
@@ -33,7 +34,10 @@ class HRAddonSettings(Document):
 	def validate_minimum_break_rules(self):
 		rules = sorted(
 			(self.minimum_break_rule or []),
-			key=lambda row: (flt(row.from_hours or 0), flt(row.to_hours or 0)),
+			key=lambda row: (
+				flt(row.from_hours or 0),
+				flt(row.to_hours) if row.to_hours is not None else inf,
+			),
 		)
 
 		if not rules:
@@ -42,12 +46,14 @@ class HRAddonSettings(Document):
 		prev_to = None
 		for index, row in enumerate(rules, start=1):
 			from_hours = flt(row.from_hours)
-			to_hours = flt(row.to_hours)
+			to_hours = flt(row.to_hours) if row.to_hours is not None else None
 
-			if from_hours < 0 or to_hours < 0:
+			if from_hours < 0:
+				frappe.throw(_("Row {0}: Hours cannot be negative.").format(index))
+			if to_hours is not None and to_hours < 0:
 				frappe.throw(_("Row {0}: Hours cannot be negative.").format(index))
 
-			if to_hours <= from_hours:
+			if to_hours is not None and to_hours <= from_hours:
 				frappe.throw(
 					_("Row {0}: To Hours must be greater than From Hours.").format(index)
 				)
@@ -61,6 +67,12 @@ class HRAddonSettings(Document):
 						"Row {0}: Rule overlaps with the previous range. "
 						"Example of invalid overlap: 0-6 and 3-5."
 					).format(index)
+				)
+
+			# Open-ended rules (blank To Hours) must be last.
+			if to_hours is None and index != len(rules):
+				frappe.throw(
+					_("Row {0}: Open-ended rule (blank To Hours) must be the last row.").format(index)
 				)
 
 			prev_to = to_hours

--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
@@ -6,6 +6,7 @@ from frappe.model.document import Document
 from frappe.utils import getdate, flt, cint
 from frappe.model.naming import make_autoname
 from frappe import _
+from math import inf
 
 class WeeklyWorkingHours(Document):
 	def autoname(self):
@@ -34,7 +35,10 @@ class WeeklyWorkingHours(Document):
 		settings = frappe.get_single("HR Addon Settings")
 		rules = sorted(
 			(settings.minimum_break_rule or []),
-			key=lambda row: (flt(row.from_hours or 0), flt(row.to_hours or 0)),
+			key=lambda row: (
+				flt(row.from_hours or 0),
+				flt(row.to_hours) if row.to_hours is not None else inf,
+			),
 		)
 		if not rules:
 			return
@@ -48,13 +52,13 @@ class WeeklyWorkingHours(Document):
 			matched_rule = None
 			for rule in rules:
 				from_hours = flt(rule.from_hours or 0)
-				to_hours = flt(rule.to_hours or 0)
+				to_hours = flt(rule.to_hours) if rule.to_hours is not None else None
 
-				# Boundaries are inclusive for the first range start (0),
-				# and then open on the left / closed on the right:
-				# 0-6 means <= 6, 6-9 means > 6 and <= 9.
-				in_lower_bound = target_hours >= from_hours if from_hours == 0 else target_hours > from_hours
-				if in_lower_bound and target_hours <= to_hours:
+				# Range semantics: from_hours <= target_hours < to_hours.
+				# If to_hours is blank, rule is open-ended (>= from_hours).
+				in_lower_bound = target_hours >= from_hours
+				in_upper_bound = True if to_hours is None else target_hours < to_hours
+				if in_lower_bound and in_upper_bound:
 					matched_rule = rule
 					break
 


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2158
issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2220

Description :
This pull request refines how minimum break rules are handled and validated in both the `HRAddonSettings` and `WeeklyWorkingHours` doctypes. The changes improve the logic for open-ended rules (where `to_hours` is blank), ensure correct sorting and validation of rules, and clarify how break rules are matched to working hours.

**Minimum Break Rule Handling and Validation:**

* Sorting of rules in both `hr_addon_settings.py` and `weekly_working_hours.py` now treats blank `to_hours` as infinite, ensuring open-ended rules are always sorted last. [[1]](diffhunk://#diff-3a6eacecc508eec72dfa45c706ac9f9f783cfa4a90eb6b111ac33882a8d77965L36-R40) [[2]](diffhunk://#diff-4c3711d4be7f93f7bc4ad18f0230b0d4085103a2b6b2d935661a37636d8a74a1L37-R41)
* Validation in `hr_addon_settings.py` enforces that open-ended rules (with blank `to_hours`) must be the last row, and improves checks for negative and invalid hour ranges. [[1]](diffhunk://#diff-3a6eacecc508eec72dfa45c706ac9f9f783cfa4a90eb6b111ac33882a8d77965L45-R56) [[2]](diffhunk://#diff-3a6eacecc508eec72dfa45c706ac9f9f783cfa4a90eb6b111ac33882a8d77965R72-R77)

**Break Rule Matching Logic:**

* In `weekly_working_hours.py`, the logic for matching a break rule to a working hour range is clarified: ranges are now interpreted as `from_hours <= target_hours < to_hours`, and open-ended rules apply when `to_hours` is blank.

**Other:**

* Added `from math import inf` in both files to support the new sorting logic. [[1]](diffhunk://#diff-3a6eacecc508eec72dfa45c706ac9f9f783cfa4a90eb6b111ac33882a8d77965R14) [[2]](diffhunk://#diff-4c3711d4be7f93f7bc4ad18f0230b0d4085103a2b6b2d935661a37636d8a74a1R9)