### PR TITLE
update break rule

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('HR Addon Settings', {
 	refresh: function(frm) {
+		seed_default_minimum_break_rules_in_form(frm);
         frm.set_query("anniversary_notification_email_list", function () {
             return {
                 filters: {
@@ -81,6 +82,24 @@ frappe.ui.form.on('HR Addon Settings', {
 		})
 	}
 });
+
+function get_default_minimum_break_rules() {
+	return [
+		{ from_hours: 0, to_hours: 6, minimum_break_minutes: 0 },
+		{ from_hours: 6, to_hours: 9, minimum_break_minutes: 30 },
+		{ from_hours: 9, to_hours: 100, minimum_break_minutes: 45 },
+	];
+}
+
+function seed_default_minimum_break_rules_in_form(frm) {
+	if (!frm.doc || !Array.isArray(frm.doc.minimum_break_rule)) return;
+	if (frm.doc.minimum_break_rule.length > 0) return;
+
+	get_default_minimum_break_rules().forEach((row) => {
+		frm.add_child("minimum_break_rule", row);
+	});
+	frm.refresh_field("minimum_break_rule");
+}
 
 function generateRandomString(length) {
 	const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -188,6 +188,7 @@
    "label": "Allow Workdays on Holidays"
   },
   {
+   "description": "Used to auto-fill Weekly Working Hours > Hours > Break Minutes when the value is 0. If users edit Break Minutes manually, it cannot be saved below the matching minimum rule.",
    "fieldname": "minimum_break_rule",
    "fieldtype": "Table",
    "label": "Minimum Break Rule",
@@ -202,7 +203,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-30 15:26:01.229153",
+ "modified": "2026-05-05 10:26:01.229153",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -28,8 +28,22 @@ class HRAddonSettings(Document):
 			os.remove("{}/public/files/Urlaubskalender.ics".format(frappe.utils.get_site_path()))
 	
 	def validate(self):
+		self.set_default_minimum_break_rules()
 		self.create_background_job_if_not_exists()
 		self.validate_minimum_break_rules()
+
+	def set_default_minimum_break_rules(self):
+		"""Seed default break-rule rows when table is empty."""
+		if self.minimum_break_rule:
+			return
+
+		default_rules = [
+			{"from_hours": 0, "to_hours": 6, "minimum_break_minutes": 0},
+			{"from_hours": 6, "to_hours": 9, "minimum_break_minutes": 30},
+			{"from_hours": 9, "to_hours": 100, "minimum_break_minutes": 45},
+		]
+		for rule in default_rules:
+			self.append("minimum_break_rule", rule)
      
 	def validate_minimum_break_rules(self):
 		rules = sorted(

--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
@@ -28,6 +28,22 @@ class WeeklyWorkingHours(Document):
 		self.validate_overlapping_records_in_specific_interval()
 		self.set_break_hours_if_not_set()
 
+	def _get_rule_break_minutes(self, rules, target_hours):
+		for rule_index, rule in enumerate(rules):
+			from_hours = flt(rule.from_hours or 0)
+			to_hours = flt(rule.to_hours) if rule.to_hours is not None else None
+
+			# Boundary semantics requested:
+			# - first row: from_hours <= target_hours <= to_hours
+			# - next rows: from_hours < target_hours <= to_hours
+			# - open-ended row: target_hours > from_hours (except first row, which is >=)
+			in_lower_bound = target_hours >= from_hours if rule_index == 0 else target_hours > from_hours
+			in_upper_bound = True if to_hours is None else target_hours <= to_hours
+			if in_lower_bound and in_upper_bound:
+				return cint(rule.minimum_break_minutes or 0)
+
+		return None
+
 	def set_break_hours_if_not_set(self):
 		if not self.hours:
 			return
@@ -46,24 +62,30 @@ class WeeklyWorkingHours(Document):
 		for hour_row in self.hours:
 			target_hours = flt(hour_row.hours)
 			current_break_minutes = cint(hour_row.break_minutes or 0)
-			if target_hours <= 0 or current_break_minutes != 0:
+			if target_hours <= 0:
 				continue
 
-			matched_rule = None
-			for rule in rules:
-				from_hours = flt(rule.from_hours or 0)
-				to_hours = flt(rule.to_hours) if rule.to_hours is not None else None
+			required_break_minutes = self._get_rule_break_minutes(rules, target_hours)
+			if required_break_minutes is None:
+				continue
 
-				# Range semantics: from_hours <= target_hours < to_hours.
-				# If to_hours is blank, rule is open-ended (>= from_hours).
-				in_lower_bound = target_hours >= from_hours
-				in_upper_bound = True if to_hours is None else target_hours < to_hours
-				if in_lower_bound and in_upper_bound:
-					matched_rule = rule
-					break
+			if current_break_minutes == 0:
+				hour_row.break_minutes = required_break_minutes
+				continue
 
-			if matched_rule:
-				hour_row.break_minutes = cint(matched_rule.minimum_break_minutes or 0)
+			if current_break_minutes < required_break_minutes:
+				# If user enters lower break than the mandatory rule, reset it
+				# back to the matched minimum instead of blocking save.
+				row_label = hour_row.day or _("Unknown day")
+				frappe.msgprint(
+					_(
+						"Break Minutes for row '{0}' cannot be less than {1} "
+						"for target hours {2}."
+					).format(row_label, required_break_minutes, target_hours),
+					alert=True,
+					indicator="orange",
+				)
+				hour_row.break_minutes = required_break_minutes
 
 	def validate_if_employee_is_active(self):
 		if self.employee and frappe.get_value('Employee', self.employee, 'status') != "Active":

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -705,6 +705,7 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
 
     default_break_minutes = employee_default_work_hour.break_minutes
     default_break_hours = flt(default_break_minutes / 60)
+    expected_break_hours = default_break_hours
     target_hours = employee_default_work_hour.hours
 
     if len(employee_checkins) % 2 == 0:
@@ -743,6 +744,7 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
                 on_site_duration_hours=total_duration,
                 fallback_break_hours=default_break_hours,
             )
+            expected_break_hours = mandatory_break_hours
             if break_from_checkins <= mandatory_break_hours:
                 break_hours = mandatory_break_hours
             else:
@@ -766,7 +768,7 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
             "target_hours": target_hours,
             "break_minutes": default_break_minutes,
             "hours_worked": hours_worked,
-            "expected_break_hours": default_break_hours,
+            "expected_break_hours": expected_break_hours,
             "actual_working_hours": actual_working_hours,
             "nbreak": 0,
             "attendance": attendance,
@@ -800,7 +802,7 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
         "target_hours": target_hours,
         "break_minutes": default_break_minutes,
         "hours_worked": hours_worked,
-        "expected_break_hours": default_break_hours,
+        "expected_break_hours": expected_break_hours,
         "actual_working_hours": actual_working_hours,
         "nbreak": 0,
         "attendance": attendance,

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -661,6 +661,38 @@ def calculate_actual_working_hours(hours_worked, break_hours, default_break_hour
 		else:
 			return flt(hours_worked - default_break_hours)
 
+
+def get_mandatory_break_hours_from_settings(on_site_duration_hours, fallback_break_hours=0):
+	"""Resolve mandatory break from HR Addon Settings > Minimum Break Rule using on-site duration."""
+	on_site_duration_hours = flt(on_site_duration_hours)
+	fallback_break_hours = flt(fallback_break_hours)
+	if on_site_duration_hours <= 0:
+		return fallback_break_hours
+
+	hr_addon_settings = frappe.get_cached_doc("HR Addon Settings")
+	rules = sorted(
+		(hr_addon_settings.minimum_break_rule or []),
+		key=lambda row: (
+			flt(row.from_hours or 0),
+			flt(row.to_hours) if row.to_hours is not None else float("inf"),
+		),
+	)
+	if not rules:
+		return fallback_break_hours
+
+	for idx, rule in enumerate(rules):
+		from_hours = flt(rule.from_hours or 0)
+		to_hours = flt(rule.to_hours) if rule.to_hours is not None else None
+
+		# Keep same boundary semantics already used in Weekly Working Hours:
+		# first row inclusive lower bound, later rows strict lower bound.
+		in_lower_bound = on_site_duration_hours >= from_hours if idx == 0 else on_site_duration_hours > from_hours
+		in_upper_bound = True if to_hours is None else on_site_duration_hours <= to_hours
+		if in_lower_bound and in_upper_bound:
+			return flt(cint(rule.minimum_break_minutes or 0) / 60.0)
+
+	return fallback_break_hours
+
 def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
     hr_addon_settings = frappe.get_cached_doc("HR Addon Settings")
     is_break_from_checkins_with_swapped_hours = hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Employee Checkins" and hr_addon_settings.swap_hours_worked_and_actual_working_hours
@@ -707,8 +739,12 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
             break_hours = default_break_hours
 
         elif hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
-            if break_from_checkins <= default_break_hours:
-                break_hours = default_break_hours
+            mandatory_break_hours = get_mandatory_break_hours_from_settings(
+                on_site_duration_hours=total_duration,
+                fallback_break_hours=default_break_hours,
+            )
+            if break_from_checkins <= mandatory_break_hours:
+                break_hours = mandatory_break_hours
             else:
                 break_hours = break_from_checkins
         else:


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2158
issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2220

Description :

This pull request introduces a new "Minimum Break Rule" feature to the HR Addon, ensuring that break times are automatically suggested and enforced according to configurable rules. The changes include both backend and frontend logic to seed default rules, apply them when calculating break times, and update the UI and configuration accordingly.

**Minimum Break Rule enforcement and automation:**

* Added a new `minimum_break_rule` table to `HR Addon Settings`, with a description and UI logic to auto-seed default rules if the table is empty. [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R191) [[2]](diffhunk://#diff-33dc82e13281c13d61ae961ab1d76b65581fe900b7844cb16c94a5cf4a6ed93aR6) [[3]](diffhunk://#diff-33dc82e13281c13d61ae961ab1d76b65581fe900b7844cb16c94a5cf4a6ed93aR86-R103)
* On the backend, implemented logic to seed default minimum break rules when the settings are empty, and to enforce these rules when validating or saving.
* In `Weekly Working Hours`, refactored the logic for assigning and validating break minutes per day: break minutes are now auto-filled from the matching rule if unset, and if a user enters a value below the minimum, it is reset and a warning is shown instead of blocking the save. [[1]](diffhunk://#diff-4c3711d4be7f93f7bc4ad18f0230b0d4085103a2b6b2d935661a37636d8a74a1R31-R46) [[2]](diffhunk://#diff-4c3711d4be7f93f7bc4ad18f0230b0d4085103a2b6b2d935661a37636d8a74a1L49-R88)

**Workday calculation updates:**

* Updated workday calculation logic to use the new minimum break rule table when determining the mandatory break for a given on-site duration, ensuring consistency across the application. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R664-R695) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L710-R749)
* The output of workday calculations now reflects the expected break hours based on the minimum break rules, not just the default. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R708) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L733-R771) [[3]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L767-R805)

**Other:**

* Updated the `modified` timestamp in the settings JSON to reflect the change.