### PR TITLE
add half day holiday

### DIFF
--- a/hr_addon/hr_addon/doctype/half_day_holidays/half_day_holidays.json
+++ b/hr_addon/hr_addon/doctype/half_day_holidays/half_day_holidays.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-05-20 12:54:47.088897",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_ej2l",
+  "holiday_date",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_ej2l",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "holiday_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Description"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-05-20 12:55:36.996485",
+ "modified_by": "Administrator",
+ "module": "HR Addon",
+ "name": "Half Day Holidays",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hr_addon/hr_addon/doctype/half_day_holidays/half_day_holidays.py
+++ b/hr_addon/hr_addon/doctype/half_day_holidays/half_day_holidays.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class HalfDayHolidays(Document):
+	pass

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -22,6 +22,8 @@
   "workday_break_calculation_mechanism",
   "swap_hours_worked_and_actual_working_hours",
   "workday_break_calculation_logic",
+  "half_day_holidays_section_section",
+  "half_day_holidays",
   "notification_section",
   "anniversary_notification_email_list",
   "enable_work_anniversaries_notification",
@@ -198,12 +200,24 @@
    "fieldname": "break_rules_tab",
    "fieldtype": "Tab Break",
    "label": "Break Minutes Rules"
+  },
+  {
+   "fieldname": "half_day_holidays_section_section",
+   "fieldtype": "Section Break",
+   "label": "Half Day Holidays"
+  },
+  {
+   "description": "Dates that count as half-day holidays. On these days, target working hours are 50% of the employee\u2019s normal daily target (e.g. 24 Dec, 31 Dec). This avoids treating half a day\u2019s work as full overtime or as missing hours.",
+   "fieldname": "half_day_holidays",
+   "fieldtype": "Table",
+   "label": "Half Day Holidays",
+   "options": "Half Day Holidays"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-05-05 10:26:01.229153",
+ "modified": "2026-05-20 13:13:02.799303",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -19,6 +19,9 @@ class Workday(Document):
 		self.validate_duplicate_workday()
 		self.set_status_for_leave_application()
 
+	def before_save(self):
+		self.set_half_day_holiday()
+
 	def after_insert(self):
 		"""Show a concise message after creating a Workday, indicating its status."""
 		if self.status == "Missing Checkin":
@@ -117,6 +120,9 @@ class Workday(Document):
 			self.hours_worked = 0.0
 			self.actual_working_hours = -self.target_hours
 			self.break_hours = 0.0
+
+	def set_half_day_holiday(self):
+		apply_half_day_holiday_targets(self)
 
 	def validate_duplicate_workday(self):
 		workday = frappe.db.exists("Workday", {
@@ -834,6 +840,43 @@ def get_employee_attendance(employee,atime):
     ).run(as_dict=True)
 
     return attendance_list
+
+
+def is_half_day_holiday(adate):
+	"""True if adate is listed in HR Addon Settings > Half Day Holidays."""
+	adate = getdate(adate)
+	return frappe.db.exists(
+		"Half Day Holidays",
+		{
+			"parent": "HR Addon Settings",
+			"parenttype": "HR Addon Settings",
+			"parentfield": "half_day_holidays",
+			"holiday_date": adate,
+		},
+	)
+
+
+def apply_half_day_holiday_targets(doc, employee_default_work_hour=None):
+	"""Halve target_hours and expected_break_hours on configured half-day holidays."""
+	if not is_half_day_holiday(doc.log_date):
+		return
+
+	# Leave application already adjusts target hours for that day.
+	if doc.status in ("On Leave", "Half Day"):
+		return
+
+	if flt(doc.target_hours) > 0:
+		doc.target_hours = flt(doc.target_hours) / 2
+		doc.expected_break_hours = flt(doc.expected_break_hours) / 2
+		return
+
+	if employee_default_work_hour is None and doc.employee:
+		employee_default_work_hour = get_employee_default_work_hour(doc.employee, doc.log_date)
+	if not employee_default_work_hour:
+		return
+
+	doc.target_hours = flt(employee_default_work_hour.hours) / 2
+	doc.expected_break_hours = flt(employee_default_work_hour.break_minutes) / 60 / 2
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2156
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2313

Description  : 
This pull request introduces support for configuring and handling half-day holidays in the HR Addon. It adds a new `Half Day Holidays` table to the settings, updates the `Workday` logic to recognize these dates, and ensures that target working hours and break times are halved on specified days. This helps avoid overcounting overtime or missing hours on traditional half-day holidays.

**Half-Day Holidays Feature:**

* Added a new DocType `Half Day Holidays` (as a child table) with fields for date and description, and integrated it into `HR Addon Settings` for easy configuration. [[1]](diffhunk://#diff-99e012920229303004861fbfc02d984ee3f78c37cf5228727849fcbbbf489519R1-R46) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R25-R26) [[3]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R203-R220)
* Updated the `Workday` DocType logic to check if a workday falls on a half-day holiday and, if so, automatically halve the target working hours and expected break hours for that day. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R22-R24) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R124-R126) [[3]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R845-R881)

**Supporting Implementation:**

* Added backend logic to determine if a date is a half-day holiday and to apply the adjusted working hour targets, ensuring compatibility with leave applications and employee-specific work hours.
* Introduced a new Python class for the `Half Day Holidays` DocType to support the new table structure.