### PR TITLE
add checkbox to enable and disable checkbox

### DIFF
--- a/hr_addon/events/attendance.py
+++ b/hr_addon/events/attendance.py
@@ -94,6 +94,11 @@ def create_overtime_ledger_entry_on_attendance_submit(doc, method=None):
 
 	Balance calculation happens automatically in OvertimeLedgerEntry.validate()
 	"""
+	from hr_addon.events.overtime_ledger import is_overtime_ledger_enabled
+
+	if not is_overtime_ledger_enabled():
+		return
+
 	# Check if overtime ledger entry already exists
 	if hasattr(doc, 'custom_overtime_ledger_entry') and doc.custom_overtime_ledger_entry:
 		frappe.msgprint(
@@ -230,7 +235,12 @@ def reverse_attendance_overtime_ledger_entry(attendance_name, silent=False):
 		"remarks": f"Reversal of {ole_name} on cancellation of {doc.name}",
 		"balance_before": original_ole.balance_after,
 		"balance_after": original_ole.balance_before,
-	})
+	}, allow_when_disabled=True)
+
+	if not reversal_ole:
+		frappe.db.set_value("Overtime Ledger Entry", original_ole.name, "is_cancelled", 1, update_modified=True)
+		frappe.db.commit()
+		return True
 
 	frappe.db.set_value("Overtime Ledger Entry", original_ole.name, "is_cancelled", 1, update_modified=True)
 	frappe.db.commit()

--- a/hr_addon/events/leave_application.py
+++ b/hr_addon/events/leave_application.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from frappe.utils import add_days, flt, get_time, getdate
 
-from hr_addon.events.overtime_ledger import get_employee_overtime_balance
+from hr_addon.events.overtime_ledger import get_employee_overtime_balance, is_overtime_ledger_enabled
 from hr_addon.hr_addon.doctype.overtime_ledger_entry.overtime_ledger_entry import make_ole_entry
 from hr_addon.hr_addon.doctype.workday.workday import get_employee_default_work_hour
 
@@ -15,6 +15,9 @@ def validate_leave_application(doc, method=None):
 	Check if employee has sufficient overtime balance for leave types that deduct from overtime.
 	"""
 	if frappe.flags.get("skip_overtime_leave_validation"):
+		return
+
+	if not is_overtime_ledger_enabled():
 		return
 
 	if not doc.leave_type:
@@ -172,7 +175,7 @@ def reverse_workday_leave_ole(workday_name, silent=True):
 		"remarks": f"Reversal of {ole_name} for Workday {workday_name}",
 		"balance_before": original_ole.balance_after,
 		"balance_after": original_ole.balance_before,
-	})
+	}, allow_when_disabled=True)
 
 	frappe.db.set_value("Overtime Ledger Entry", original_ole.name, "is_cancelled", 1, update_modified=True)
 
@@ -242,7 +245,7 @@ def restore_overtime_on_leave_cancel(doc, method=None):
 			"remarks": f"Reversal of {ole_name} on cancellation of {doc.name}",
 			"balance_before": original_ole.balance_after,
 			"balance_after": original_ole.balance_before,
-		})
+		}, allow_when_disabled=True)
 
 		frappe.db.set_value("Overtime Ledger Entry", original_ole.name, "is_cancelled", 1, update_modified=True)
 		frappe.db.commit()

--- a/hr_addon/events/overtime_ledger.py
+++ b/hr_addon/events/overtime_ledger.py
@@ -8,6 +8,20 @@ from frappe.query_builder.functions import Count
 REVERSAL_REMARK_MARKER = "Reversal of"
 
 
+def is_overtime_ledger_enabled():
+	"""Master switch from HR Addon Settings (Overtime Ledger tab)."""
+	return cint(frappe.db.get_single_value("HR Addon Settings", "enable_overtime_legder_feature"))
+
+
+def require_overtime_ledger_enabled(message=None):
+	"""Raise when overtime ledger is disabled (submit / manual create paths)."""
+	if not is_overtime_ledger_enabled():
+		frappe.throw(
+			message
+			or _("Enable Overtime Ledger Feature in HR Addon Settings before using overtime ledger.")
+		)
+
+
 def is_reversal_ledger_row(remarks):
 	"""True if remarks match explicit reversal rows (English marker from reverse_* helpers)."""
 	return bool(remarks and REVERSAL_REMARK_MARKER in str(remarks))
@@ -53,6 +67,9 @@ def after_insert_overtime_ledger_entry(doc, method=None):
 	
 	This is called on after_insert hook
 	"""
+	if not is_overtime_ledger_enabled() and not is_reversal_ledger_row(doc.remarks):
+		return
+
 	# Check if there are entries AFTER this one that need reposting
 	OLE = frappe.qb.DocType("Overtime Ledger Entry")
 	

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -34,6 +34,7 @@
   "break_rules_tab",
   "minimum_break_rule",
   "overtime_ledger_tab",
+  "enable_overtime_legder_feature",
   "overtime_frozen",
   "select_employees",
   "repost_all_oles"
@@ -240,12 +241,19 @@
    "fieldname": "repost_all_oles",
    "fieldtype": "Button",
    "label": "Repost All Overtime Ledger Entries"
+  },
+  {
+   "default": "0",
+   "description": "Master switch for the overtime ledger. When enabled: Attendance and Workday create Overtime Ledger entries, Overtime Payout can be submitted, OT-deduct leave validation runs, and repost is available. When disabled: no new ledger entries are created (use for hr_addon-only sites without overtime). Existing entries can still be reversed on cancel.",
+   "fieldname": "enable_overtime_legder_feature",
+   "fieldtype": "Check",
+   "label": "Enable Overtime Legder Feature"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-05-21 15:19:26.164267",
+ "modified": "2026-05-22 11:23:28.265930",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.py
@@ -380,7 +380,10 @@ def repost_all_overtime_ledger_entries(employees=None):
 	"""Recalculate overtime balances after the frozen date for all or selected employees."""
 	import json
 
-	from hr_addon.events.overtime_ledger import update_entries_after
+	from hr_addon.events.overtime_ledger import is_overtime_ledger_enabled, update_entries_after
+
+	if not is_overtime_ledger_enabled():
+		return _("Overtime Ledger feature is disabled in HR Addon Settings.")
 
 	settings = frappe.get_single("HR Addon Settings")
 	overtime_frozen = getattr(settings, "overtime_frozen", None)

--- a/hr_addon/hr_addon/doctype/overtime_ledger_entry/overtime_ledger_entry.py
+++ b/hr_addon/hr_addon/doctype/overtime_ledger_entry/overtime_ledger_entry.py
@@ -87,6 +87,20 @@ class OvertimeLedgerEntry(Document):
 
 		# Require Overtime Hours Frozen Upto in HR Addon Settings
 		if self.posting_date:
+			from hr_addon.events.overtime_ledger import (
+				is_overtime_ledger_enabled,
+				is_reversal_ledger_row,
+			)
+
+			if self.is_new() and not is_reversal_ledger_row(self.remarks):
+				if not is_overtime_ledger_enabled():
+					frappe.throw(
+						_(
+							"Enable Overtime Ledger Feature in HR Addon Settings before creating Overtime Ledger entries."
+						),
+						title=_("Overtime Ledger Disabled"),
+					)
+
 			settings = frappe.get_single("HR Addon Settings")
 			overtime_frozen = getattr(settings, "overtime_frozen", None)
 			if not overtime_frozen:
@@ -190,7 +204,7 @@ class OvertimeLedgerEntry(Document):
 # MODULE-LEVEL HELPER FUNCTIONS FOR overtime pay-out
 # ============================================================================
 
-def make_ole_entry(args):
+def make_ole_entry(args, allow_when_disabled=False):
 	"""
 	Create Overtime Ledger Entry
 	Following make_entry() pattern from erpnext.stock.stock_ledger
@@ -200,10 +214,15 @@ def make_ole_entry(args):
 	
 	Args:
 		args: Dictionary with OLE fields
+		allow_when_disabled: True for reversals when cleaning up existing ledger rows
 		
 	Returns:
-		OLE document
+		OLE document, or None when feature is disabled
 	"""
+	from hr_addon.events.overtime_ledger import is_overtime_ledger_enabled
+
+	if not allow_when_disabled and not is_overtime_ledger_enabled():
+		return None
 	
 	args["doctype"] = "Overtime Ledger Entry"
 	ole = frappe.get_doc(args)
@@ -279,4 +298,4 @@ def make_ole_entries(ole_entries):
 	# Create OLE entries
 	for ole in ole_entries:
 		if ole.get("hour_variance") or cancel:
-			ole_doc = make_ole_entry(ole)			
+			make_ole_entry(ole, allow_when_disabled=bool(cancel))

--- a/hr_addon/hr_addon/doctype/overtime_ledger_entry/test_overtime_ledger_entry.py
+++ b/hr_addon/hr_addon/doctype/overtime_ledger_entry/test_overtime_ledger_entry.py
@@ -48,6 +48,7 @@ class TestOvertimeLedgerEntry(FrappeTestCase):
 		"""Persist HR Addon Settings closed-period cutoff (shared test helper)."""
 		doc = frappe.get_single("HR Addon Settings")
 		doc.overtime_frozen = overtime_frozen
+		doc.enable_overtime_legder_feature = 1
 		doc.save()
 
 	def get_leave_type_deducting_overtime(self):
@@ -711,6 +712,7 @@ class TestLeaveApplicationOvertimeLedger(FrappeTestCase):
 	def _ensure_open_period_for_ole(self):
 		doc = frappe.get_single("HR Addon Settings")
 		doc.overtime_frozen = add_days(getdate(), -180)
+		doc.enable_overtime_legder_feature = 1
 		doc.save()
 
 	def _require_attendance_ole_fields(self):

--- a/hr_addon/hr_addon/doctype/overtime_payout/overtime_payout.py
+++ b/hr_addon/hr_addon/doctype/overtime_payout/overtime_payout.py
@@ -3,7 +3,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, flt, get_time, getdate, nowtime
-from hr_addon.events.overtime_ledger import get_employee_overtime_balance
+from hr_addon.events.overtime_ledger import get_employee_overtime_balance, require_overtime_ledger_enabled
 
 
 class OvertimePayout(Document):
@@ -39,6 +39,9 @@ class OvertimePayout(Document):
 		On submit: Create Overtime Ledger Entry
 		Following Stock Entry pattern
 		"""
+		require_overtime_ledger_enabled(
+			_("Enable Overtime Ledger Feature in HR Addon Settings before submitting Overtime Payout.")
+		)
 		self.update_overtime_ledger()
 		self._update_overtime_balance_after_submit()
 
@@ -192,7 +195,9 @@ class OvertimePayout(Document):
 					ole["balance_before"] = original_oles[i].balance_after
 					ole["balance_after"] = original_oles[i].balance_before
 				
-				ole_doc = make_ole_entry(ole)
+				ole_doc = make_ole_entry(ole, allow_when_disabled=True)
+				if not ole_doc:
+					continue
 				frappe.msgprint(
 					_("Reversal Overtime Ledger Entry {0} created to cancel {1}").format(
 						ole_doc.name, self.name
@@ -228,7 +233,9 @@ class OvertimePayout(Document):
 			# Create new OLE entries
 			for ole in ole_entries:
 				ole_doc = make_ole_entry(ole)
-				
+				if not ole_doc:
+					continue
+
 				# Show message
 				action = "reduced" if self.purpose in ("Pay-out", "Negative Adjustment") else "increased"
 				frappe.msgprint(

--- a/hr_addon/hr_addon/doctype/overtime_payout/test_overtime_payout.py
+++ b/hr_addon/hr_addon/doctype/overtime_payout/test_overtime_payout.py
@@ -40,6 +40,7 @@ class TestOvertimePayout(FrappeTestCase):
 	def _set_frozen_past(self):
 		doc = frappe.get_single("HR Addon Settings")
 		doc.overtime_frozen = add_days(getdate(), -180)
+		doc.enable_overtime_legder_feature = 1
 		doc.save()
 
 	def _submit_payout(self, employee, posting_date, purpose, hours_seconds):

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -1621,6 +1621,11 @@ def _handle_overtime_ledger(
     doc, attendance, hour_variance, target_for_att, actual_for_att, leave_info=None
 ):
     """Create or update Overtime Ledger Entry"""
+    from hr_addon.events.overtime_ledger import is_overtime_ledger_enabled
+
+    if not is_overtime_ledger_enabled():
+        return
+
     leave_type = getattr(leave_info, "leave_type", None) or getattr(attendance, "leave_type", None)
     ole_variance = get_ole_hour_variance_for_attendance(
         status=getattr(doc, "status", None),

--- a/hr_addon/patches.txt
+++ b/hr_addon/patches.txt
@@ -2,3 +2,4 @@
 
 [post_model_sync]
 hr_addon.patches.v1_0.migrate_overtime_doctypes_to_hr_addon_module
+hr_addon.patches.v1_0.remove_legacy_suncycle_ole_custom_fields

--- a/hr_addon/patches/v1_0/remove_legacy_suncycle_ole_custom_fields.py
+++ b/hr_addon/patches/v1_0/remove_legacy_suncycle_ole_custom_fields.py
@@ -1,0 +1,41 @@
+import frappe
+
+# Custom fields now owned by hr_addon fixtures (module HR Addon).
+LEGACY_OLE_CUSTOM_FIELDS = {
+	"Attendance": (
+		"custom_working_hours_details",
+		"custom_target_hours",
+		"custom_workday",
+		"custom_actual_working_hours",
+		"custom_hour_variance",
+		"custom_column_break_salzc",
+		"custom_create_overtime_ledger_entry",
+		"custom_overtime_ledger_entry",
+	),
+	"Employee": (
+		"custom_working_hours",
+		"custom_weekly_working_hours",
+		"custom_working_hours_cb",
+		"custom_total_work_hours",
+		"custom_overtime_ledger_details",
+		"custom_current_overtime_hours",
+		"custom_column_break_r4uli",
+		"custom_overtime_ledger_entry",
+	),
+	"Leave Type": ("custom_is_deducted_from_overtime_ledger",),
+}
+
+
+def execute():
+	"""Remove duplicate OLE/working-hours custom fields still registered under Suncycle."""
+	for dt, fieldnames in LEGACY_OLE_CUSTOM_FIELDS.items():
+		for fieldname in fieldnames:
+			legacy_names = frappe.get_all(
+				"Custom Field",
+				filters={"dt": dt, "fieldname": fieldname, "module": ["!=", "HR Addon"]},
+				pluck="name",
+			)
+			for name in legacy_names:
+				frappe.delete_doc("Custom Field", name, force=True, ignore_permissions=True)
+
+	frappe.clear_cache(doctype="Custom Field")


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2310
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2311

Description :

This pull request introduces a master switch to enable or disable the Overtime Ledger feature throughout the HR Addon. When disabled, no new overtime ledger entries are created, overtime-related validations and payouts are blocked, and related operations are skipped, while reversals of existing entries are still allowed. The implementation includes a new setting in `HR Addon Settings`, code changes to respect the switch in all relevant workflows, and updates to tests and patches.

**Overtime Ledger Feature Toggle Implementation:**

* Added a new checkbox field `enable_overtime_legder_feature` to `HR Addon Settings` as a master switch for the Overtime Ledger feature, with descriptive help text. [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R37) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7R244-R256)
* Introduced helper functions `is_overtime_ledger_enabled()` and `require_overtime_ledger_enabled()` in `hr_addon/events/overtime_ledger.py` to check and enforce the feature's enabled state.
* Updated all overtime ledger entry creation, validation, and payout code paths (including attendance, leave, workday, and payout modules) to respect the master switch, skipping or blocking actions as appropriate. [[1]](diffhunk://#diff-f5fcccea8622f580f6bf0e5fad5085044279926f97ff20b61a36a7f33cf10064R97-R101) [[2]](diffhunk://#diff-7325912ba184c02816b0407201e73cb8c8684708098ca1e0f9ce6a1c46bd3719R20-R22) [[3]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R1624-R1628) [[4]](diffhunk://#diff-8dcdd6b2bcbdbbb47dd82e867354974eb440ad1def92addfacc52b0c33da1caaR42-R44) [[5]](diffhunk://#diff-8dcdd6b2bcbdbbb47dd82e867354974eb440ad1def92addfacc52b0c33da1caaR236-R237) [[6]](diffhunk://#diff-7b3c820552100901c8f38efe899d160ea024f56757799ef73722c45987ca8ce2R90-R103) [[7]](diffhunk://#diff-7b3c820552100901c8f38efe899d160ea024f56757799ef73722c45987ca8ce2R217-R225) [[8]](diffhunk://#diff-7b3c820552100901c8f38efe899d160ea024f56757799ef73722c45987ca8ce2L282-R301) [[9]](diffhunk://#diff-8023f971f5cecde581612aeddb5b2b92426af8cd6b7acc10d0b2c6ca07602678R70-R72) [[10]](diffhunk://#diff-3a6eacecc508eec72dfa45c706ac9f9f783cfa4a90eb6b111ac33882a8d77965L383-R386)
* Ensured that reversal and cancellation logic for existing overtime ledger entries is always allowed, even when the feature is disabled, by introducing the `allow_when_disabled` parameter to `make_ole_entry`. [[1]](diffhunk://#diff-f5fcccea8622f580f6bf0e5fad5085044279926f97ff20b61a36a7f33cf10064L233-R243) [[2]](diffhunk://#diff-7325912ba184c02816b0407201e73cb8c8684708098ca1e0f9ce6a1c46bd3719L175-R178) [[3]](diffhunk://#diff-7325912ba184c02816b0407201e73cb8c8684708098ca1e0f9ce6a1c46bd3719L245-R248) [[4]](diffhunk://#diff-8dcdd6b2bcbdbbb47dd82e867354974eb440ad1def92addfacc52b0c33da1caaL195-R200) [[5]](diffhunk://#diff-7b3c820552100901c8f38efe899d160ea024f56757799ef73722c45987ca8ce2L193-R207)

**Testing and Maintenance:**

* Updated test helpers to ensure the Overtime Ledger feature is enabled during test setup and teardown. [[1]](diffhunk://#diff-e31ef6996d2dd6f6ab1ae8fb5e686ef46eb4f5f66823e28e1e74343d98c4a1d8R51) [[2]](diffhunk://#diff-e31ef6996d2dd6f6ab1ae8fb5e686ef46eb4f5f66823e28e1e74343d98c4a1d8R715) [[3]](diffhunk://#diff-812ab3a6db547da48bd506fdbd517ac69cdea36e6f231956c91a105fb91f246eR43)
* Added a new patch to remove legacy custom fields related to overtime ledger functionality that are no longer needed, improving maintainability. [[1]](diffhunk://#diff-8dd1c35e35c7deafdf44ced49d2840e5a8a1beeca2d81f021f272594263cd621R5) [[2]](diffhunk://#diff-2e1aac358e310c97a45ae80fea1f06b310921bbc7e28ac29ee01e843e601abc8R1-R41)