### PR TITLE
voucher links + rename updated

### DIFF
--- a/hr_addon/events/overtime_ledger.py
+++ b/hr_addon/events/overtime_ledger.py
@@ -10,7 +10,7 @@ REVERSAL_REMARK_MARKER = "Reversal of"
 
 def is_overtime_ledger_enabled():
 	"""Master switch from HR Addon Settings (Overtime Ledger tab)."""
-	return cint(frappe.db.get_single_value("HR Addon Settings", "enable_overtime_legder_feature"))
+	return cint(frappe.db.get_single_value("HR Addon Settings", "enable_overtime_ledger_feature"))
 
 
 def require_overtime_ledger_enabled(message=None):

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -34,7 +34,7 @@
   "break_rules_tab",
   "minimum_break_rule",
   "overtime_ledger_tab",
-  "enable_overtime_legder_feature",
+  "enable_overtime_ledger_feature",
   "overtime_frozen",
   "select_employees",
   "repost_all_oles"
@@ -245,15 +245,15 @@
   {
    "default": "0",
    "description": "Master switch for the overtime ledger. When enabled: Attendance and Workday create Overtime Ledger entries, Overtime Payout can be submitted, OT-deduct leave validation runs, and repost is available. When disabled: no new ledger entries are created (use for hr_addon-only sites without overtime). Existing entries can still be reversed on cancel.",
-   "fieldname": "enable_overtime_legder_feature",
+   "fieldname": "enable_overtime_ledger_feature",
    "fieldtype": "Check",
-   "label": "Enable Overtime Legder Feature"
+   "label": "Enable Overtime Ledger Feature"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-05-22 11:23:28.265930",
+ "modified": "2026-05-22 13:23:28.265930",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/overtime_ledger_entry/test_overtime_ledger_entry.py
+++ b/hr_addon/hr_addon/doctype/overtime_ledger_entry/test_overtime_ledger_entry.py
@@ -48,7 +48,7 @@ class TestOvertimeLedgerEntry(FrappeTestCase):
 		"""Persist HR Addon Settings closed-period cutoff (shared test helper)."""
 		doc = frappe.get_single("HR Addon Settings")
 		doc.overtime_frozen = overtime_frozen
-		doc.enable_overtime_legder_feature = 1
+		doc.enable_overtime_ledger_feature = 1
 		doc.save()
 
 	def get_leave_type_deducting_overtime(self):
@@ -712,7 +712,7 @@ class TestLeaveApplicationOvertimeLedger(FrappeTestCase):
 	def _ensure_open_period_for_ole(self):
 		doc = frappe.get_single("HR Addon Settings")
 		doc.overtime_frozen = add_days(getdate(), -180)
-		doc.enable_overtime_legder_feature = 1
+		doc.enable_overtime_ledger_feature = 1
 		doc.save()
 
 	def _require_attendance_ole_fields(self):

--- a/hr_addon/hr_addon/doctype/overtime_payout/test_overtime_payout.py
+++ b/hr_addon/hr_addon/doctype/overtime_payout/test_overtime_payout.py
@@ -40,7 +40,7 @@ class TestOvertimePayout(FrappeTestCase):
 	def _set_frozen_past(self):
 		doc = frappe.get_single("HR Addon Settings")
 		doc.overtime_frozen = add_days(getdate(), -180)
-		doc.enable_overtime_legder_feature = 1
+		doc.enable_overtime_ledger_feature = 1
 		doc.save()
 
 	def _submit_payout(self, employee, posting_date, purpose, hours_seconds):

--- a/hr_addon/hr_addon/report/overtime_ledger/overtime_ledger.js
+++ b/hr_addon/hr_addon/report/overtime_ledger/overtime_ledger.js
@@ -256,6 +256,13 @@ frappe.query_reports["Overtime Ledger"] = {
 			} else {
 				value = "";
 			}
+		} else if (
+			column.fieldname === "voucher_no" &&
+			data &&
+			data.voucher_type &&
+			data.voucher_no
+		) {
+			value = frappe.utils.get_form_link(data.voucher_type, data.voucher_no, true);
 		}
 
 		// Apply cancelled/reversal styling at the end so formatted value is preserved

--- a/hr_addon/hr_addon/report/overtime_ledger/overtime_ledger.json
+++ b/hr_addon/hr_addon/report/overtime_ledger/overtime_ledger.json
@@ -7,10 +7,10 @@
  "docstatus": 0,
  "doctype": "Report",
  "filters": [],
- "idx": 0,
+ "idx": 2,
  "is_standard": "Yes",
  "letter_head": null,
- "modified": "2026-04-27 13:26:34.232956",
+ "modified": "2026-05-22 14:39:44.382138",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Overtime Ledger",
@@ -25,9 +25,6 @@
   },
   {
    "role": "HR Manager"
-  },
-  {
-   "role": "SC HR"
   }
  ],
  "timeout": 0


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2310
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2311

Description :

This pull request primarily fixes a typo in the "Enable Overtime Ledger Feature" setting throughout the codebase, ensuring consistent naming and preventing potential bugs. Additionally, it improves the `Overtime Ledger` report by adding clickable links to voucher numbers for better usability.

**Bug fix: Overtime Ledger feature flag typo correction**
- Renamed all instances of the setting from `enable_overtime_legder_feature` to `enable_overtime_ledger_feature` in code, JSON schema, and test files, ensuring the feature flag works correctly and consistently. [[1]](diffhunk://#diff-8023f971f5cecde581612aeddb5b2b92426af8cd6b7acc10d0b2c6ca07602678L13-R13) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L37-R37) [[3]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L248-R256) [[4]](diffhunk://#diff-e31ef6996d2dd6f6ab1ae8fb5e686ef46eb4f5f66823e28e1e74343d98c4a1d8L51-R51) [[5]](diffhunk://#diff-e31ef6996d2dd6f6ab1ae8fb5e686ef46eb4f5f66823e28e1e74343d98c4a1d8L715-R715) [[6]](diffhunk://#diff-812ab3a6db547da48bd506fdbd517ac69cdea36e6f231956c91a105fb91f246eL43-R43)

**Usability improvement: Overtime Ledger report**
- Added clickable links to the `voucher_no` field in the `Overtime Ledger` report, allowing users to quickly navigate to related documents.

**Minor metadata updates**
- Updated the `idx` and `modified` fields in the `Overtime Ledger` report JSON for consistency.
- Cleaned up report permissions by removing the `SC HR` role from the report's allowed roles.