### PR TITLE
no attendace create if flag is off

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -244,7 +244,7 @@
   },
   {
    "default": "0",
-   "description": "Master switch for the overtime ledger. When enabled: Attendance and Workday create Overtime Ledger entries, Overtime Payout can be submitted, OT-deduct leave validation runs, and repost is available. When disabled: no new ledger entries are created (use for hr_addon-only sites without overtime). Existing entries can still be reversed on cancel.",
+   "description": "Master switch for the overtime ledger. When enabled: Workday creates Attendance and Overtime Ledger entries, Overtime Payout can be submitted, OT-deduct leave validation runs, and repost is available. When disabled: Workday does not create new Attendance (existing Attendance for a day can still be updated on Workday save), no new ledger entries are created, and repost is unavailable. Existing entries can still be reversed on cancel.",
    "fieldname": "enable_overtime_ledger_feature",
    "fieldtype": "Check",
    "label": "Enable Overtime Ledger Feature"
@@ -253,7 +253,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-05-22 13:23:28.265930",
+ "modified": "2026-05-26 13:23:28.265930",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/overtime_ledger_entry/test_overtime_ledger_entry.py
+++ b/hr_addon/hr_addon/doctype/overtime_ledger_entry/test_overtime_ledger_entry.py
@@ -51,6 +51,11 @@ class TestOvertimeLedgerEntry(FrappeTestCase):
 		doc.enable_overtime_ledger_feature = 1
 		doc.save()
 
+	def set_hr_addon_overtime_enabled(self, enabled=1):
+		doc = frappe.get_single("HR Addon Settings")
+		doc.enable_overtime_ledger_feature = 1 if enabled else 0
+		doc.save()
+
 	def get_leave_type_deducting_overtime(self):
 		"""First Leave Type flagged to deduct from overtime ledger, if any."""
 		row = frappe.get_all(
@@ -715,6 +720,11 @@ class TestLeaveApplicationOvertimeLedger(FrappeTestCase):
 		doc.enable_overtime_ledger_feature = 1
 		doc.save()
 
+	def set_hr_addon_overtime_enabled(self, enabled=1):
+		doc = frappe.get_single("HR Addon Settings")
+		doc.enable_overtime_ledger_feature = 1 if enabled else 0
+		doc.save()
+
 	def _require_attendance_ole_fields(self):
 		meta = frappe.get_meta("Attendance")
 		if not (
@@ -1236,6 +1246,124 @@ class TestLeaveApplicationOvertimeLedger(FrappeTestCase):
 		self.assertAlmostEqual(
 			flt(frappe.db.get_value("Overtime Ledger Entry", ole_name, "hour_variance")),
 			2.0,
+			places=4,
+		)
+
+	def test_workday_skips_new_attendance_when_ole_feature_disabled(self):
+		"""Workday must not create Attendance when OLE feature is off and none exists yet."""
+		self._require_attendance_ole_fields()
+		self._ensure_open_period_for_ole()
+		self.set_hr_addon_overtime_enabled(0)
+		log_date = add_days(getdate(), 3)
+		employee = make_employee(
+			f"ole_wd_no_att_{uuid.uuid4().hex[:10]}@test.local",
+			company="_Test Company",
+		)
+		wd = frappe.get_doc(
+			{
+				"doctype": "Workday",
+				"employee": employee,
+				"log_date": log_date,
+				"company": "_Test Company",
+				"status": "Present",
+				"target_hours": 8,
+				"actual_working_hours": 7.5,
+			}
+		)
+		create_attendace_record(wd)
+		self.assertFalse(
+			frappe.db.exists(
+				"Attendance",
+				{"employee": employee, "attendance_date": log_date, "docstatus": 1},
+			)
+		)
+
+	def test_workday_updates_existing_attendance_when_ole_feature_disabled(self):
+		"""When OLE is off, Workday may still sync hours onto an existing submitted Attendance."""
+		self._require_attendance_ole_fields()
+		self._ensure_open_period_for_ole()
+		log_date = add_days(getdate(), 4)
+		employee = make_employee(
+			f"ole_wd_upd_off_{uuid.uuid4().hex[:10]}@test.local",
+			company="_Test Company",
+		)
+		attendance = frappe.get_doc(
+			{
+				"doctype": "Attendance",
+				"employee": employee,
+				"attendance_date": log_date,
+				"status": "Present",
+				"company": "_Test Company",
+				"custom_target_hours": 8,
+				"custom_actual_working_hours": 7,
+			}
+		)
+		attendance.flags.ignore_permissions = True
+		attendance.insert()
+		try:
+			attendance.submit()
+		except Exception as exc:
+			self.skipTest(f"Attendance submit not supported in this environment: {exc}")
+
+		self.set_hr_addon_overtime_enabled(0)
+		wd = frappe.get_doc(
+			{
+				"doctype": "Workday",
+				"employee": employee,
+				"log_date": log_date,
+				"company": "_Test Company",
+				"status": "Present",
+				"target_hours": 8,
+				"actual_working_hours": 9,
+				"attendance": attendance.name,
+			}
+		)
+		create_attendace_record(wd)
+		self.assertAlmostEqual(
+			flt(
+				frappe.db.get_value(
+					"Attendance", attendance.name, "custom_actual_working_hours"
+				)
+			),
+			9.0,
+			places=4,
+		)
+
+	def test_workday_creates_attendance_when_ole_feature_enabled(self):
+		"""When OLE is on, Workday creates submitted Attendance for a Present day."""
+		self._require_attendance_ole_fields()
+		self._ensure_open_period_for_ole()
+		self.set_hr_addon_overtime_enabled(1)
+		log_date = add_days(getdate(), 5)
+		employee = make_employee(
+			f"ole_wd_create_{uuid.uuid4().hex[:10]}@test.local",
+			company="_Test Company",
+		)
+		wd = frappe.get_doc(
+			{
+				"doctype": "Workday",
+				"employee": employee,
+				"log_date": log_date,
+				"company": "_Test Company",
+				"status": "Present",
+				"target_hours": 8,
+				"actual_working_hours": 7.5,
+			}
+		)
+		create_attendace_record(wd)
+		attendance_name = frappe.db.get_value(
+			"Attendance",
+			{"employee": employee, "attendance_date": log_date, "docstatus": 1},
+			"name",
+		)
+		self.assertTrue(attendance_name)
+		self.assertAlmostEqual(
+			flt(
+				frappe.db.get_value(
+					"Attendance", attendance_name, "custom_actual_working_hours"
+				)
+			),
+			7.5,
 			places=4,
 		)
 

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -1582,6 +1582,7 @@ def _create_new_attendance(doc, hour_variance, att_status, target_for_att, actua
         "doctype": "Attendance",
         "employee": doc.employee,
         "attendance_date": doc.log_date,
+        "company": doc.company or frappe.db.get_value("Employee", doc.employee, "company"),
         "status": att_status,
         "custom_workday": doc.name,
         "custom_target_hours": target_for_att,

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -1455,6 +1455,18 @@ def get_submitted_leave_application(employee, log_date, require_ot_deduct=False)
 	return frappe._dict(name=la, leave_type=leave_type)
 
 
+def _get_submitted_attendance_for_workday(doc):
+	"""Submitted Attendance for this Workday day (by link or employee/date lookup)."""
+	linked = getattr(doc, "attendance", None)
+	if linked and frappe.db.get_value("Attendance", linked, "docstatus") == 1:
+		return linked
+
+	return frappe.db.exists(
+		"Attendance",
+		{"employee": doc.employee, "attendance_date": doc.log_date, "docstatus": 1},
+	)
+
+
 def create_attendace_record(doc, method=None):
     """
     Create or update Attendance for OLE via the same path as Attendance.on_submit.
@@ -1463,11 +1475,20 @@ def create_attendace_record(doc, method=None):
 
     On Leave (full day, OT-deduct leave type): target = default day hours, actual = 0.
 
+    When Enable Overtime Ledger Feature is off: skip creating new Attendance from Workday,
+    but still update an existing submitted Attendance if one is already linked.
+
     Deleting a Workday cancels linked Attendance (OLE reversed). On recreate, a new
     Attendance is submitted; OLE is created on submit when hour variance is non-zero.
     If weekly hours cannot resolve target for On Leave, reuse custom_target_hours from
     the last cancelled Attendance for that date when available.
     """
+    from hr_addon.events.overtime_ledger import is_overtime_ledger_enabled
+
+    existing_attendance = _get_submitted_attendance_for_workday(doc)
+    if not is_overtime_ledger_enabled() and not existing_attendance:
+        return
+
     att_status = None
     target_for_att = None
     actual_for_att = None
@@ -1534,7 +1555,7 @@ def create_attendace_record(doc, method=None):
 
     hour_variance = flt(actual_for_att) - flt(target_for_att)
 
-    attendance_exists = attendance_exists_early or frappe.db.exists(
+    attendance_exists = existing_attendance or frappe.db.exists(
         "Attendance",
         {"employee": doc.employee, "attendance_date": doc.log_date, "docstatus": 1},
     )

--- a/hr_addon/public/js/leave_application.js
+++ b/hr_addon/public/js/leave_application.js
@@ -1,12 +1,5 @@
 frappe.ui.form.on("Leave Application", {
 	employee(frm) {
-		frm.set_query("leave_type", function () {
-			return {
-				filters: {
-					enabled: 1,
-				},
-			};
-		});
 		frm.trigger("update_overtime_leave_balance_indicator");
 	},
 


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2310
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2311

Description :

This pull request updates the logic for creating Attendance records from Workday documents based on the "Enable Overtime Ledger Feature" setting, and adds new tests to ensure correct behavior. The main focus is to prevent Workday from creating new Attendance records when the Overtime Ledger feature is disabled, while still allowing updates to existing Attendance records. It also clarifies the feature's description and introduces a helper for toggling the setting in tests.

**Behavioral changes to Attendance creation from Workday:**

* Updated `create_attendace_record` in `workday.py` to skip creating new Attendance records when the Overtime Ledger feature is disabled, but still allow updating an existing submitted Attendance if already linked. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R1478-R1491) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R1458-R1469) [[3]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L1537-R1558)

**Test enhancements:**

* Added tests in `test_overtime_ledger_entry.py` to verify:
  - No new Attendance is created from Workday when the feature is disabled.
  - Existing Attendance records can still be updated from Workday when the feature is disabled.
  - Normal Attendance creation from Workday when the feature is enabled.
* Introduced a helper method `set_hr_addon_overtime_enabled` for toggling the feature in tests. [[1]](diffhunk://#diff-e31ef6996d2dd6f6ab1ae8fb5e686ef46eb4f5f66823e28e1e74343d98c4a1d8R54-R58) [[2]](diffhunk://#diff-e31ef6996d2dd6f6ab1ae8fb5e686ef46eb4f5f66823e28e1e74343d98c4a1d8R723-R727)

**Documentation and metadata updates:**

* Clarified the description for the "Enable Overtime Ledger Feature" setting in `hr_addon_settings.json` to accurately reflect the new behavior.
* Updated the `modified` timestamp in `hr_addon_settings.json` for record-keeping.