### PR TITLE
remove break hours fallback

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -185,27 +185,33 @@ function get_break_calculation_logic_html(mechanism, swapEnabled = false) {
 			bg1: '#e7f3ff',
 			bg2: '#fff3cd',
 			bg3: '#d1ecf1',
+			bg4: '#e8f5e9',
 			border1: '#007bff',
 			border2: '#ffc107',
 			border3: '#17a2b8',
+			border4: '#28a745',
 			text: '#333',
 			textSecondary: '#666',
 			heading1: '#007bff',
 			heading2: '#856404',
-			heading3: '#0c5460'
+			heading3: '#0c5460',
+			heading4: '#155724'
 		},
 		dark: {
 			bg1: 'rgba(0, 123, 255, 0.15)',
 			bg2: 'rgba(255, 193, 7, 0.15)',
 			bg3: 'rgba(23, 162, 184, 0.15)',
+			bg4: 'rgba(40, 167, 69, 0.15)',
 			border1: '#4dabf7',
 			border2: '#ffd43b',
 			border3: '#66d9ef',
+			border4: '#51cf66',
 			text: 'var(--text-color)',
 			textSecondary: 'var(--text-muted)',
 			heading1: '#4dabf7',
 			heading2: '#ffd43b',
-			heading3: '#66d9ef'
+			heading3: '#66d9ef',
+			heading4: '#51cf66'
 		}
 	};
 	
@@ -262,13 +268,18 @@ function get_break_calculation_logic_html(mechanism, swapEnabled = false) {
 			<div style="padding: 15px; background-color: ${theme.bg2}; border-left: 4px solid ${theme.border2}; margin: 10px 0; border-radius: 4px;">
 				<h4 style="margin-top: 0; color: ${theme.heading2}; font-size: 14px; font-weight: 600;">Break Hours from Weekly Working Hours</h4>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
-					<strong>Logic:</strong> Uses the predefined break time configured in Weekly Working Hours.
+					<strong>Logic:</strong> Fixed break from Weekly Working Hours for that weekday. Minimum Break Rule and check-in gaps are not used.
 				</p>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
-					<strong>Calculation:</strong> The break hours are taken directly from the Weekly Working Hours configuration (break_minutes converted to hours). This is a fixed value regardless of actual checkin patterns.
+					<strong>Calculation:</strong>
+					<ul style="margin: 8px 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6;">
+						<li><strong>Expected break hours:</strong> Weekly Working Hours break_minutes ÷ 60</li>
+						<li><strong>Break hours:</strong> Same fixed weekly value</li>
+						<li><strong>Actual working hours:</strong> Hours worked (work segments) − break hours</li>
+					</ul>
 				</p>
 				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
-					<strong>Note:</strong> The actual break time from checkins is ignored. The system always uses the configured break time from Weekly Working Hours.
+					<strong>Example:</strong> Monday break_minutes = 30 → break hours always 0.5, even if the employee took no lunch in check-ins.
 				</p>
 			</div>
 		`,
@@ -276,18 +287,37 @@ function get_break_calculation_logic_html(mechanism, swapEnabled = false) {
 			<div style="padding: 15px; background-color: ${theme.bg3}; border-left: 4px solid ${theme.border3}; margin: 10px 0; border-radius: 4px;">
 				<h4 style="margin-top: 0; color: ${theme.heading3}; font-size: 14px; font-weight: 600;">Break Hours from Weekly Working Hours if Shorter breaks</h4>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
-					<strong>Logic:</strong> Compares the actual break time from checkins with the mandatory break from Minimum Break Rule (by on-site hours).
+					<strong>Logic:</strong> Compares check-in lunch gaps with the break from Weekly Working Hours. Minimum Break Rule is not used.
 				</p>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
 					<strong>Calculation:</strong>
 					<ul style="margin: 8px 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6;">
-						<li><strong>Expected break hours:</strong> From Minimum Break Rule using first check-in to last checkout</li>
-						<li>If actual break from checkins ≤ expected break hours: Uses expected (mandatory) break</li>
-						<li>If actual break from checkins > expected break hours: Uses the actual break time from checkins</li>
+						<li><strong>Expected break hours:</strong> Weekly Working Hours break_minutes ÷ 60</li>
+						<li><strong>Break hours:</strong> Weekly default if check-in gap ≤ expected; otherwise the actual gap from check-ins</li>
+						<li><strong>Actual working hours:</strong> On-site time − break hours</li>
 					</ul>
 				</p>
 				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
-					<strong>Example:</strong> If mandatory break is 0.5 hours (30 min) but employee took 1 hour break, the system uses 1 hour. If employee took only 0.25 hours break, the system uses 0.5 hours (mandatory).
+					<strong>Example:</strong> Weekly break 0.5 h, gap 0.25 h → break 0.5 h. Weekly break 0.5 h, gap 1 h → break 1 h.
+				</p>
+			</div>
+		`,
+		"Break Hours from Minimum Break Rule": `
+			<div style="padding: 15px; background-color: ${theme.bg4}; border-left: 4px solid ${theme.border4}; margin: 10px 0; border-radius: 4px;">
+				<h4 style="margin-top: 0; color: ${theme.heading4}; font-size: 14px; font-weight: 600;">Break Hours from Minimum Break Rule</h4>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Logic:</strong> Always applies the mandatory break from HR Addon Settings → Minimum Break Rule. Check-in gaps are ignored for break hours.
+				</p>
+				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
+					<strong>Calculation:</strong>
+					<ul style="margin: 8px 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6;">
+						<li><strong>Expected break hours:</strong> Minimum Break Rule (on-site: first check-in → last checkout)</li>
+						<li><strong>Break hours:</strong> Always equal to expected break hours</li>
+						<li><strong>Actual working hours:</strong> On-site time − break hours</li>
+					</ul>
+				</p>
+				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
+					<strong>Example:</strong> On-site 8.5 h → mandatory 0.5 h break even if check-ins show a 1 h lunch or no lunch split. Use “if Shorter breaks” when longer real breaks must be credited.
 				</p>
 			</div>
 		`

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -276,17 +276,18 @@ function get_break_calculation_logic_html(mechanism, swapEnabled = false) {
 			<div style="padding: 15px; background-color: ${theme.bg3}; border-left: 4px solid ${theme.border3}; margin: 10px 0; border-radius: 4px;">
 				<h4 style="margin-top: 0; color: ${theme.heading3}; font-size: 14px; font-weight: 600;">Break Hours from Weekly Working Hours if Shorter breaks</h4>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
-					<strong>Logic:</strong> Compares the actual break time from checkins with the default break hours from Weekly Working Hours.
+					<strong>Logic:</strong> Compares the actual break time from checkins with the mandatory break from Minimum Break Rule (by on-site hours).
 				</p>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
 					<strong>Calculation:</strong>
 					<ul style="margin: 8px 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6;">
-						<li>If actual break from checkins ≤ default break hours: Uses default break hours from Weekly Working Hours</li>
-						<li>If actual break from checkins > default break hours: Uses the actual break time from checkins</li>
+						<li><strong>Expected break hours:</strong> From Minimum Break Rule using first check-in to last checkout</li>
+						<li>If actual break from checkins ≤ expected break hours: Uses expected (mandatory) break</li>
+						<li>If actual break from checkins > expected break hours: Uses the actual break time from checkins</li>
 					</ul>
 				</p>
 				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
-					<strong>Example:</strong> If default break is 0.5 hours (30 min) but employee took 1 hour break, the system uses 1 hour. If employee took only 0.25 hours break, the system uses 0.5 hours (default).
+					<strong>Example:</strong> If mandatory break is 0.5 hours (30 min) but employee took 1 hour break, the system uses 1 hour. If employee took only 0.25 hours break, the system uses 0.5 hours (mandatory).
 				</p>
 			</div>
 		`

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -195,7 +195,7 @@
    "label": "Allow Workdays on Holidays"
   },
   {
-   "description": "Used to auto-fill Weekly Working Hours > Hours > Break Minutes when the value is 0. If users edit Break Minutes manually, it cannot be saved below the matching minimum rule.",
+   "description": "Mandatory break by on-site hours for Workdays (Expected Break Hours) and to auto-fill Weekly Working Hours Break Minutes when 0. Workday break hours are not taken from Weekly Working Hours when mechanism is \"if Shorter breaks\".",
    "fieldname": "minimum_break_rule",
    "fieldtype": "Table",
    "label": "Minimum Break Rule",

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -154,10 +154,11 @@
   },
   {
    "default": "Break Hours from Employee Checkins",
+   "description": "How Workday break and expected break hours are calculated from Employee Checkins. See explanation below when you change this field.",
    "fieldname": "workday_break_calculation_mechanism",
    "fieldtype": "Select",
    "label": "Workday break Calculation Mechanism",
-   "options": "Break Hours from Employee Checkins\nBreak Hours from Weekly Working Hours\nBreak Hours from Weekly Working Hours if Shorter breaks"
+   "options": "Break Hours from Employee Checkins\nBreak Hours from Weekly Working Hours\nBreak Hours from Weekly Working Hours if Shorter breaks\nBreak Hours from Minimum Break Rule"
   },
   {
    "default": "0",
@@ -183,6 +184,7 @@
    "label": "Skip Workdays for Employees without Weekly Hours"
   },
   {
+   "description": "Updated automatically when Workday break Calculation Mechanism changes. Describes expected break hours, break hours, and actual working hours for the selected option.",
    "fieldname": "workday_break_calculation_logic",
    "fieldtype": "HTML",
    "label": "Break Calculation Logic Explanation"
@@ -195,7 +197,7 @@
    "label": "Allow Workdays on Holidays"
   },
   {
-   "description": "Mandatory break by on-site hours for Workdays (Expected Break Hours) and to auto-fill Weekly Working Hours Break Minutes when 0. Workday break hours are not taken from Weekly Working Hours when mechanism is \"if Shorter breaks\".",
+   "description": "Used for Workday break hours when mechanism is Break Hours from Minimum Break Rule. Also auto-fills Weekly Working Hours Break Minutes when 0 and enforces minimum on manual edits.",
    "fieldname": "minimum_break_rule",
    "fieldtype": "Table",
    "label": "Minimum Break Rule",
@@ -253,7 +255,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-05-26 13:23:28.265930",
+ "modified": "2026-06-03 15:55:49.467711",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -657,7 +657,7 @@ def calculate_actual_working_hours(hours_worked, break_hours, default_break_hour
 	Args:
 		hours_worked: Sum of work periods (excluding breaks)
 		break_hours: Calculated break hours
-		default_break_hours: Default break hours from Weekly Working Hours
+		default_break_hours: Default break hours from Weekly Working Hours (legacy mechanisms only)
 		mechanism: Break calculation mechanism from HR Addon Settings (optional, will fetch if not provided)
 		total_duration: Total time from first checkin to last checkout (optional, for Workday)
 		is_swapped: Whether hours_worked and total_duration are swapped (optional, will fetch if not provided)
@@ -698,6 +698,8 @@ def calculate_actual_working_hours(hours_worked, break_hours, default_break_hour
 			return flt(total_duration - break_hours)
 		elif hours_worked > 0:
 			return flt(hours_worked - break_hours)
+		elif mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
+			return flt(hours_worked - break_hours) if hours_worked > 0 else flt((total_duration or 0) - break_hours)
 		else:
 			return flt(total_duration - default_break_hours) if total_duration is not None else flt(hours_worked - default_break_hours)
 	
@@ -705,16 +707,17 @@ def calculate_actual_working_hours(hours_worked, break_hours, default_break_hour
 		# Default: hours_worked contains sum of work periods (excluding breaks)
 		if total_duration is not None and total_duration > 0:
 			return flt(hours_worked - break_hours)
+		elif mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
+			return flt(hours_worked - break_hours)
 		else:
 			return flt(hours_worked - default_break_hours)
 
 
-def get_mandatory_break_hours_from_settings(on_site_duration_hours, fallback_break_hours=0):
+def get_mandatory_break_hours_from_settings(on_site_duration_hours):
 	"""Resolve mandatory break from HR Addon Settings > Minimum Break Rule using on-site duration."""
 	on_site_duration_hours = flt(on_site_duration_hours)
-	fallback_break_hours = flt(fallback_break_hours)
 	if on_site_duration_hours <= 0:
-		return fallback_break_hours
+		return 0.0
 
 	hr_addon_settings = frappe.get_cached_doc("HR Addon Settings")
 	rules = sorted(
@@ -725,7 +728,7 @@ def get_mandatory_break_hours_from_settings(on_site_duration_hours, fallback_bre
 		),
 	)
 	if not rules:
-		return fallback_break_hours
+		return 0.0
 
 	for idx, rule in enumerate(rules):
 		from_hours = flt(rule.from_hours or 0)
@@ -738,7 +741,7 @@ def get_mandatory_break_hours_from_settings(on_site_duration_hours, fallback_bre
 		if in_lower_bound and in_upper_bound:
 			return flt(cint(rule.minimum_break_minutes or 0) / 60.0)
 
-	return fallback_break_hours
+	return 0.0
 
 def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
     hr_addon_settings = frappe.get_cached_doc("HR Addon Settings")
@@ -752,7 +755,7 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
 
     default_break_minutes = employee_default_work_hour.break_minutes
     default_break_hours = flt(default_break_minutes / 60)
-    expected_break_hours = default_break_hours
+    expected_break_hours = 0.0
     target_hours = employee_default_work_hour.hours
 
     if len(employee_checkins) % 2 == 0:
@@ -775,6 +778,9 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
         if is_break_from_checkins_with_swapped_hours:
             total_duration, hours_worked = hours_worked, total_duration
 
+        if total_duration > 0:
+            expected_break_hours = get_mandatory_break_hours_from_settings(total_duration)
+
         break_from_checkins = 0.0
         for i in range(len(clockout_list) - 1):
             wh = time_diff_in_hours(clockin_list[i + 1], clockout_list[i])
@@ -787,11 +793,7 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
             break_hours = default_break_hours
 
         elif hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
-            mandatory_break_hours = get_mandatory_break_hours_from_settings(
-                on_site_duration_hours=total_duration,
-                fallback_break_hours=default_break_hours,
-            )
-            expected_break_hours = mandatory_break_hours
+            mandatory_break_hours = expected_break_hours
             if break_from_checkins <= mandatory_break_hours:
                 break_hours = mandatory_break_hours
             else:

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -755,7 +755,7 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
 
     default_break_minutes = employee_default_work_hour.break_minutes
     default_break_hours = flt(default_break_minutes / 60)
-    expected_break_hours = 0.0
+    expected_break_hours = default_break_hours
     target_hours = employee_default_work_hour.hours
 
     if len(employee_checkins) % 2 == 0:
@@ -778,7 +778,8 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
         if is_break_from_checkins_with_swapped_hours:
             total_duration, hours_worked = hours_worked, total_duration
 
-        if total_duration > 0:
+        mechanism = hr_addon_settings.workday_break_calculation_mechanism
+        if mechanism == "Break Hours from Weekly Working Hours if Shorter breaks" and total_duration > 0:
             expected_break_hours = get_mandatory_break_hours_from_settings(total_duration)
 
         break_from_checkins = 0.0
@@ -786,13 +787,13 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
             wh = time_diff_in_hours(clockin_list[i + 1], clockout_list[i])
             break_from_checkins += float(wh)
 
-        if hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Employee Checkins":
+        if mechanism == "Break Hours from Employee Checkins":
             break_hours = break_from_checkins
 
-        elif hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours":
+        elif mechanism == "Break Hours from Weekly Working Hours":
             break_hours = default_break_hours
 
-        elif hr_addon_settings.workday_break_calculation_mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
+        elif mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
             mandatory_break_hours = expected_break_hours
             if break_from_checkins <= mandatory_break_hours:
                 break_hours = mandatory_break_hours

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -16,6 +16,13 @@ from hr_addon.events.attendance import (
 )
 import traceback
 
+MECHANISM_MINIMUM_BREAK_RULE = "Break Hours from Minimum Break Rule"
+MECHANISMS_ACTUAL_WORKING_HOURS_FROM_ON_SITE = (
+	"Break Hours from Weekly Working Hours if Shorter breaks",
+	MECHANISM_MINIMUM_BREAK_RULE,
+)
+
+
 class Workday(Document):
 	def validate(self):
 		self.set_actual_employee_log()
@@ -684,13 +691,10 @@ def calculate_actual_working_hours(hours_worked, break_hours, default_break_hour
 		return hours_worked
 	
 	# Calculate based on mechanism
-	if mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
-		# For this mechanism: use total_duration (total presence on site) minus break_hours
+	if mechanism in MECHANISMS_ACTUAL_WORKING_HOURS_FROM_ON_SITE:
 		if total_duration is not None and total_duration > 0:
 			return flt(total_duration - break_hours)
-		else:
-			# Fallback: use hours_worked - break_hours if total_duration not available
-			return flt(hours_worked - break_hours)
+		return flt(hours_worked - break_hours)
 	
 	elif is_swapped:
 		# When swap is enabled: hours_worked contains total_duration
@@ -698,8 +702,6 @@ def calculate_actual_working_hours(hours_worked, break_hours, default_break_hour
 			return flt(total_duration - break_hours)
 		elif hours_worked > 0:
 			return flt(hours_worked - break_hours)
-		elif mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
-			return flt(hours_worked - break_hours) if hours_worked > 0 else flt((total_duration or 0) - break_hours)
 		else:
 			return flt(total_duration - default_break_hours) if total_duration is not None else flt(hours_worked - default_break_hours)
 	
@@ -707,7 +709,7 @@ def calculate_actual_working_hours(hours_worked, break_hours, default_break_hour
 		# Default: hours_worked contains sum of work periods (excluding breaks)
 		if total_duration is not None and total_duration > 0:
 			return flt(hours_worked - break_hours)
-		elif mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
+		elif mechanism in MECHANISMS_ACTUAL_WORKING_HOURS_FROM_ON_SITE:
 			return flt(hours_worked - break_hours)
 		else:
 			return flt(hours_worked - default_break_hours)
@@ -779,8 +781,6 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
             total_duration, hours_worked = hours_worked, total_duration
 
         mechanism = hr_addon_settings.workday_break_calculation_mechanism
-        if mechanism == "Break Hours from Weekly Working Hours if Shorter breaks" and total_duration > 0:
-            expected_break_hours = get_mandatory_break_hours_from_settings(total_duration)
 
         break_from_checkins = 0.0
         for i in range(len(clockout_list) - 1):
@@ -794,11 +794,14 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
             break_hours = default_break_hours
 
         elif mechanism == "Break Hours from Weekly Working Hours if Shorter breaks":
-            mandatory_break_hours = expected_break_hours
-            if break_from_checkins <= mandatory_break_hours:
-                break_hours = mandatory_break_hours
+            if break_from_checkins <= default_break_hours:
+                break_hours = default_break_hours
             else:
                 break_hours = break_from_checkins
+        elif mechanism == MECHANISM_MINIMUM_BREAK_RULE:
+            if total_duration > 0:
+                expected_break_hours = get_mandatory_break_hours_from_settings(total_duration)
+            break_hours = expected_break_hours
         else:
             break_hours = 0.0
 


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2158
issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2220

Description :

This pull request updates the break calculation logic for workdays to consistently use the "Minimum Break Rule" (mandatory break by on-site hours) instead of defaulting to "Weekly Working Hours" break minutes in certain scenarios. The changes clarify the logic in both the backend and the UI, ensuring that expected break hours are always derived from the Minimum Break Rule when the "if Shorter breaks" mechanism is selected.

**Break Calculation Logic Updates:**

* The calculation and description of break hours for the "if Shorter breaks" mechanism now use the expected break from the Minimum Break Rule (based on on-site hours) rather than the default break from Weekly Working Hours. [[1]](diffhunk://#diff-33dc82e13281c13d61ae961ab1d76b65581fe900b7844cb16c94a5cf4a6ed93aL279-R290) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L198-R198)
* The backend logic in `get_workday` and `calculate_actual_working_hours` has been updated so that expected/mandatory break hours are always pulled from the Minimum Break Rule when using this mechanism, and fallback to default break hours is removed. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L755-R758) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R781-R783) [[3]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L790-R796) [[4]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R701-R720)

**Code and Documentation Consistency:**

* The description for the Minimum Break Rule field in the settings JSON is updated to clarify its role as the sole source for expected break hours when using the "if Shorter breaks" mechanism.
* Function signatures and docstrings have been updated to clarify that default break hours are now legacy/fallback for older mechanisms only.

**Refactoring and Cleanup:**

* The `get_mandatory_break_hours_from_settings` function no longer accepts or returns a fallback value; it always returns 0.0 if no rule matches or if duration is non-positive. [[1]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639R701-R720) [[2]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L728-R731) [[3]](diffhunk://#diff-9e01bbaa7c06704e68dbb4a2501c79a3f27dbf8b3077892180e6988ed0a04639L741-R744)