### PR TITLE
added option in break mechanism

### DIFF
--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.js
@@ -287,18 +287,18 @@ function get_break_calculation_logic_html(mechanism, swapEnabled = false) {
 			<div style="padding: 15px; background-color: ${theme.bg3}; border-left: 4px solid ${theme.border3}; margin: 10px 0; border-radius: 4px;">
 				<h4 style="margin-top: 0; color: ${theme.heading3}; font-size: 14px; font-weight: 600;">Break Hours from Weekly Working Hours if Shorter breaks</h4>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
-					<strong>Logic:</strong> Compares check-in lunch gaps with the break from Weekly Working Hours. Minimum Break Rule is not used.
+					<strong>Logic:</strong> Same “if shorter breaks” pattern as Minimum Break Rule, but the reference break comes from <strong>Weekly Working Hours</strong> only. Minimum Break Rule and weekly break_minutes from the rule table are <strong>not</strong> used.
 				</p>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
 					<strong>Calculation:</strong>
 					<ul style="margin: 8px 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6;">
-						<li><strong>Expected break hours:</strong> Weekly Working Hours break_minutes ÷ 60</li>
-						<li><strong>Break hours:</strong> Weekly default if check-in gap ≤ expected; otherwise the actual gap from check-ins</li>
+						<li><strong>Expected break hours:</strong> Weekly Working Hours break_minutes ÷ 60 (that weekday)</li>
+						<li><strong>Break hours:</strong> Expected if check-in gap ≤ expected; if the break is longer, the actual gap from check-ins is used</li>
 						<li><strong>Actual working hours:</strong> On-site time − break hours</li>
 					</ul>
 				</p>
 				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
-					<strong>Example:</strong> Weekly break 0.5 h, gap 0.25 h → break 0.5 h. Weekly break 0.5 h, gap 1 h → break 1 h.
+					<strong>Example:</strong> Weekly 0.5 h, gap 0.25 h → break 0.5 h. Weekly 0.5 h, gap 1 h → break 1 h. On-site 10 h still uses weekly 0.5 h (not the 45 min from Minimum Break Rule).
 				</p>
 			</div>
 		`,
@@ -306,18 +306,18 @@ function get_break_calculation_logic_html(mechanism, swapEnabled = false) {
 			<div style="padding: 15px; background-color: ${theme.bg4}; border-left: 4px solid ${theme.border4}; margin: 10px 0; border-radius: 4px;">
 				<h4 style="margin-top: 0; color: ${theme.heading4}; font-size: 14px; font-weight: 600;">Break Hours from Minimum Break Rule</h4>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
-					<strong>Logic:</strong> Always applies the mandatory break from HR Addon Settings → Minimum Break Rule. Check-in gaps are ignored for break hours.
+					<strong>Logic:</strong> Same “if shorter breaks” pattern, but the reference break comes from <strong>Minimum Break Rule</strong> (on-site hours). Weekly Working Hours break_minutes are <strong>not</strong> used.
 				</p>
 				<p style="margin-bottom: 8px; color: ${theme.text}; line-height: 1.6;">
 					<strong>Calculation:</strong>
 					<ul style="margin: 8px 0; padding-left: 20px; color: ${theme.text}; line-height: 1.6;">
-						<li><strong>Expected break hours:</strong> Minimum Break Rule (on-site: first check-in → last checkout)</li>
-						<li><strong>Break hours:</strong> Always equal to expected break hours</li>
+						<li><strong>Expected break hours:</strong> Minimum Break Rule (first check-in → last checkout)</li>
+						<li><strong>Break hours:</strong> Expected (mandatory) if check-in gap ≤ expected; if the break is longer, the actual gap from check-ins is used</li>
 						<li><strong>Actual working hours:</strong> On-site time − break hours</li>
 					</ul>
 				</p>
 				<p style="margin-bottom: 0; color: ${theme.textSecondary}; font-size: 12px; line-height: 1.5;">
-					<strong>Example:</strong> On-site 8.5 h → mandatory 0.5 h break even if check-ins show a 1 h lunch or no lunch split. Use “if Shorter breaks” when longer real breaks must be credited.
+					<strong>Example:</strong> On-site 8.5 h → expected 0.5 h; gap 0.25 h → break 0.5 h; gap 1 h → break 1 h. On-site 10 h → expected 0.75 h (45 min); gap 2 h → break 2 h.
 				</p>
 			</div>
 		`

--- a/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
+++ b/hr_addon/hr_addon/doctype/hr_addon_settings/hr_addon_settings.json
@@ -154,7 +154,6 @@
   },
   {
    "default": "Break Hours from Employee Checkins",
-   "description": "How Workday break and expected break hours are calculated from Employee Checkins. See explanation below when you change this field.",
    "fieldname": "workday_break_calculation_mechanism",
    "fieldtype": "Select",
    "label": "Workday break Calculation Mechanism",
@@ -184,7 +183,6 @@
    "label": "Skip Workdays for Employees without Weekly Hours"
   },
   {
-   "description": "Updated automatically when Workday break Calculation Mechanism changes. Describes expected break hours, break hours, and actual working hours for the selected option.",
    "fieldname": "workday_break_calculation_logic",
    "fieldtype": "HTML",
    "label": "Break Calculation Logic Explanation"
@@ -197,7 +195,7 @@
    "label": "Allow Workdays on Holidays"
   },
   {
-   "description": "Used for Workday break hours when mechanism is Break Hours from Minimum Break Rule. Also auto-fills Weekly Working Hours Break Minutes when 0 and enforces minimum on manual edits.",
+   "description": "Used to auto-fill Weekly Working Hours > Hours > Break Minutes when the value is 0. If users edit Break Minutes manually, it cannot be saved below the matching minimum rule.",
    "fieldname": "minimum_break_rule",
    "fieldtype": "Table",
    "label": "Minimum Break Rule",
@@ -206,7 +204,7 @@
   {
    "fieldname": "break_rules_tab",
    "fieldtype": "Tab Break",
-   "label": "Break Minutes Rules"
+   "label": "Minimum Break Rules"
   },
   {
    "fieldname": "half_day_holidays_section_section",
@@ -255,7 +253,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-03 15:55:49.467711",
+ "modified": "2026-06-03 17:49:33.500324",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "HR Addon Settings",

--- a/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
+++ b/hr_addon/hr_addon/doctype/weekly_working_hours/weekly_working_hours.py
@@ -8,6 +8,9 @@ from frappe.model.naming import make_autoname
 from frappe import _
 from math import inf
 
+MECHANISM_MINIMUM_BREAK_RULE = "Break Hours from Minimum Break Rule"
+
+
 class WeeklyWorkingHours(Document):
 	def autoname(self):
 		Company = frappe.qb.DocType('Company')
@@ -49,6 +52,9 @@ class WeeklyWorkingHours(Document):
 			return
 
 		settings = frappe.get_single("HR Addon Settings")
+		if settings.workday_break_calculation_mechanism != MECHANISM_MINIMUM_BREAK_RULE:
+			return
+
 		rules = sorted(
 			(settings.minimum_break_rule or []),
 			key=lambda row: (

--- a/hr_addon/hr_addon/doctype/workday/workday.py
+++ b/hr_addon/hr_addon/doctype/workday/workday.py
@@ -801,7 +801,11 @@ def get_workday(employee_checkins, employee_default_work_hour, no_break_hours):
         elif mechanism == MECHANISM_MINIMUM_BREAK_RULE:
             if total_duration > 0:
                 expected_break_hours = get_mandatory_break_hours_from_settings(total_duration)
-            break_hours = expected_break_hours
+            mandatory_break_hours = expected_break_hours
+            if break_from_checkins <= mandatory_break_hours:
+                break_hours = mandatory_break_hours
+            else:
+                break_hours = break_from_checkins
         else:
             break_hours = 0.0
 


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2158
issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2220

Description :

This pull request makes several improvements and clarifications to the break calculation logic in the HR Addon, both in the backend logic and in the user-facing descriptions. The main focus is to clarify how break hours are determined based on the selected calculation mechanism, especially distinguishing between the "Weekly Working Hours" and "Minimum Break Rule" approaches. Additionally, some field labels and descriptions in the settings have been updated for clarity and consistency.

**Break Calculation Logic Improvements:**

- Clarified the user-facing HTML explanations for both "Break Hours from Weekly Working Hours" and "Break Hours from Minimum Break Rule" to better describe the logic, calculation steps, and examples for each mechanism. The explanations now emphasize which rules are used for reference breaks and how actual break hours are determined.

- Updated the backend logic for the "Minimum Break Rule" mechanism so that if the check-in gap exceeds the mandatory break, the actual gap is used as the break hours; otherwise, the mandatory minimum applies. This aligns the implementation with the clarified explanation.

**Settings and Field Description Updates:**

- Improved descriptions and labels in `hr_addon_settings.json` to make the purpose and behavior of fields related to break calculation more explicit and user-friendly, including:
    - Removing outdated or redundant field descriptions. [[1]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L157) [[2]](diffhunk://#diff-1856dc8a7363cd18021073efd2dd098baa8135bd33d5b36bafa3e0b26dac15d7L187)
    - Clarifying the description for the "Minimum Break Rule" field to specify its role in auto-filling and enforcing minimum break minutes.
    - Renaming the "Break Minutes Rules" tab to "Minimum Break Rules" for consistency.

**Backend Logic Adjustments:**

- Added a constant `MECHANISM_MINIMUM_BREAK_RULE` for mechanism comparison in `weekly_working_hours.py` and updated the logic to only set break hours from the minimum break rule if this mechanism is selected. [[1]](diffhunk://#diff-4c3711d4be7f93f7bc4ad18f0230b0d4085103a2b6b2d935661a37636d8a74a1R11-R13) [[2]](diffhunk://#diff-4c3711d4be7f93f7bc4ad18f0230b0d4085103a2b6b2d935661a37636d8a74a1R55-R57)

**Other:**

- Updated the `modified` timestamp in the settings JSON to reflect the latest changes.