### PR TITLE
Added validate_filters() to require Company, From Date, and To Date

### DIFF
--- a/hr_addon/hr_addon/report/overtime_ledger/overtime_ledger.js
+++ b/hr_addon/hr_addon/report/overtime_ledger/overtime_ledger.js
@@ -16,6 +16,11 @@ const get_current_month_range = () => {
 	return { first_day, last_day };
 };
 
+const has_required_filters = () => {
+	const report = frappe.query_report;
+	return report.get_filter_value("from_date") && report.get_filter_value("to_date");
+};
+
 const sync_date_range = () => {
 	const from_date = frappe.query_report.get_filter_value("from_date");
 	const to_date = frappe.query_report.get_filter_value("to_date");
@@ -28,7 +33,6 @@ const sync_date_range = () => {
 
 	const from_date_obj = frappe.datetime.str_to_obj(from_date);
 	if (!from_date_obj) {
-		frappe.query_report.refresh();
 		return;
 	}
 
@@ -38,11 +42,15 @@ const sync_date_range = () => {
 		return;
 	}
 
-	frappe.query_report.refresh();
+	if (has_required_filters()) {
+		frappe.query_report.refresh();
+	}
 };
 
 const refresh_report = () => {
-	frappe.query_report.refresh();
+	if (has_required_filters()) {
+		frappe.query_report.refresh();
+	}
 };
 
 const { first_day, last_day } = get_current_month_range();
@@ -122,6 +130,13 @@ frappe.query_reports["Overtime Ledger"] = {
 		}
 	],
 	onload: function(report) {
+		if (!report.get_filter_value("from_date") || !report.get_filter_value("to_date")) {
+			report.set_filter_value({
+				from_date: first_day,
+				to_date: last_day,
+			});
+		}
+
 		// Page class for dual datatable styles
 		setTimeout(function () {
 			if (report && report.page && report.page.main) {

--- a/hr_addon/hr_addon/report/overtime_ledger/overtime_ledger.py
+++ b/hr_addon/hr_addon/report/overtime_ledger/overtime_ledger.py
@@ -21,7 +21,22 @@ def get_employee_link_filters():
 	return [["Employee", "status", "=", "Active"]]
 
 
+def validate_filters(filters):
+	if not filters.get("company"):
+		frappe.throw(_("{0} is mandatory").format(_("Company")))
+
+	if not filters.get("from_date") or not filters.get("to_date"):
+		frappe.throw(
+			_("{0} and {1} are mandatory").format(
+				frappe.bold(_("From Date")), frappe.bold(_("To Date"))
+			)
+		)
+
+
 def execute(filters=None):
+	filters = frappe._dict(filters or {})
+	validate_filters(filters)
+
 	columns = get_columns(filters)
 	employees = get_employees(filters)
 	employee_details = get_employee_details(employees)


### PR DESCRIPTION
parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2401
issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2402

Description  : 
This pull request improves the reliability and user experience of the "Overtime Ledger" report by ensuring that required filters are set and validated both on the frontend and backend. The main changes include adding checks to make sure "from_date" and "to_date" are set before refreshing the report, and enforcing mandatory filter validation in the backend to prevent incomplete queries.

**Frontend improvements to filter handling:**

* Added a `has_required_filters` function in `overtime_ledger.js` to check if both "from_date" and "to_date" filters are set before allowing the report to refresh. This prevents unnecessary or incomplete report loads. [[1]](diffhunk://#diff-ac2dc3884b30c451c412ef087e9ebaad174166047fa24acbac28429566c7d047R19-R23) [[2]](diffhunk://#diff-ac2dc3884b30c451c412ef087e9ebaad174166047fa24acbac28429566c7d047R45-R53)
* Updated the report's `onload` handler to automatically set default values for "from_date" and "to_date" to the current month's range if they are not already set, improving usability for first-time users.

**Backend validation:**

* Added a `validate_filters` function in `overtime_ledger.py` to enforce that "company", "from_date", and "to_date" are provided, throwing a clear error if any are missing. This ensures data integrity and prevents incomplete queries from running.
* Integrated the new validation into the `execute` function to guarantee that all required filters are checked before report data is processed.

These changes help prevent user errors and ensure that the report always runs with the necessary context.