### PR TITLE
Suncycle/suncycle#2480 suncycle v15

### DIFF
--- a/hr_addon/hr_addon/doctype/workday/workday.json
+++ b/hr_addon/hr_addon/doctype/workday/workday.json
@@ -1,12 +1,13 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:WD-{YYYY}-{#####}",
+ "autoname": "naming_series:",
  "creation": "2022-05-06 15:25:52.037042",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "naming_series",
   "employee",
   "employee_name",
   "attendance",
@@ -143,14 +144,21 @@
    "fieldtype": "Data",
    "label": "Employee Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "naming_series",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2025-03-25 16:03:45.327857",
+ "modified": "2026-07-17 23:29:52.216468",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Workday",
- "naming_rule": "Expression",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -178,6 +186,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/hr_addon/hr_addon/doctype/workday_creation_log/test_workday_creation_log.py
+++ b/hr_addon/hr_addon/doctype/workday_creation_log/test_workday_creation_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, phamos.eu and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestWorkdayCreationLog(FrappeTestCase):
+	pass

--- a/hr_addon/hr_addon/doctype/workday_creation_log/workday_creation_log.js
+++ b/hr_addon/hr_addon/doctype/workday_creation_log/workday_creation_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, phamos.eu and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Workday Creation Log", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/hr_addon/hr_addon/doctype/workday_creation_log/workday_creation_log.json
+++ b/hr_addon/hr_addon/doctype/workday_creation_log/workday_creation_log.json
@@ -1,11 +1,12 @@
 {
  "actions": [],
- "autoname": "format:WCL-{####}",
- "creation": "2024-12-05 10:00:00.000000",
+ "autoname": "naming_series:",
+ "creation": "2024-12-05 10:00:00",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "naming_series",
   "employee",
   "log_date",
   "workday",
@@ -214,15 +215,21 @@
    "fieldtype": "Link",
    "label": "Workday",
    "options": "Workday"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-05 10:00:00.000000",
+ "modified": "2026-07-17 23:30:36.471189",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Workday Creation Log",
- "naming_rule": "Expression",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -247,6 +254,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/hr_addon/hr_addon/doctype/workday_generation_log/test_workday_generation_log.py
+++ b/hr_addon/hr_addon/doctype/workday_generation_log/test_workday_generation_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, phamos.eu and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestWorkdayGenerationLog(FrappeTestCase):
+	pass

--- a/hr_addon/hr_addon/doctype/workday_generation_log/workday_generation_log.js
+++ b/hr_addon/hr_addon/doctype/workday_generation_log/workday_generation_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, phamos.eu and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Workday Generation Log", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/hr_addon/hr_addon/doctype/workday_generation_log/workday_generation_log.json
+++ b/hr_addon/hr_addon/doctype/workday_generation_log/workday_generation_log.json
@@ -1,11 +1,12 @@
 {
  "actions": [],
  "autoname": "format:WDL-{####}",
- "creation": "2025-12-04 12:00:00.000000",
+ "creation": "2025-12-04 12:00:00",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "naming_series",
   "execution_info_section",
   "execution_time",
   "execution_type",
@@ -122,15 +123,21 @@
    "fieldname": "error_log",
    "fieldtype": "Long Text",
    "label": "Error Log"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-04 12:00:00.000000",
+ "modified": "2026-07-17 23:31:15.503354",
  "modified_by": "Administrator",
  "module": "HR Addon",
  "name": "Workday Generation Log",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -155,6 +162,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
Parent : https://git.phamos.eu/suncycle/suncycle/-/issues/2480
Issue : https://git.phamos.eu/suncycle/suncycle/-/work_items/2483

Description  : 


This pull request updates the HR Addon DocTypes to standardize the use of the `naming_series` field for document naming, adds supporting fields and configuration, and introduces basic test and JavaScript files for new DocTypes. The changes improve consistency in document naming and prepare the new DocTypes for future development and testing.

**DocType configuration and naming improvements:**

* Changed the `autoname` and `naming_rule` properties in `workday`, `workday_creation_log`, and `workday_generation_log` DocTypes to use the `naming_series` field for document naming, and added a read-only `naming_series` field to each DocType. This standardizes naming conventions across these DocTypes. [[1]](diffhunk://#diff-221541e0ce35a5b59209e2cc1551225e695e841d5797cde8bb9f7056f04afd25L4-R10) [[2]](diffhunk://#diff-221541e0ce35a5b59209e2cc1551225e695e841d5797cde8bb9f7056f04afd25R147-R161) [[3]](diffhunk://#diff-c4e19d30f91c7ce049805c7d63bc67ddc2536e806e9a55270da1dc4c30131c7fL3-R9) [[4]](diffhunk://#diff-c4e19d30f91c7ce049805c7d63bc67ddc2536e806e9a55270da1dc4c30131c7fR218-R232) [[5]](diffhunk://#diff-ee4b9f7d4da43d2f2b927511d98578e69900e41c088c3e27d836962f688e9a03L4-R9) [[6]](diffhunk://#diff-ee4b9f7d4da43d2f2b927511d98578e69900e41c088c3e27d836962f688e9a03R126-R140)

* Updated the `field_order` in all three DocTypes to include the new `naming_series` field at the top, ensuring it appears first in the form layout. [[1]](diffhunk://#diff-221541e0ce35a5b59209e2cc1551225e695e841d5797cde8bb9f7056f04afd25L4-R10) [[2]](diffhunk://#diff-c4e19d30f91c7ce049805c7d63bc67ddc2536e806e9a55270da1dc4c30131c7fL3-R9) [[3]](diffhunk://#diff-ee4b9f7d4da43d2f2b927511d98578e69900e41c088c3e27d836962f688e9a03L4-R9)

* Set the `row_format` property to `"Dynamic"` for all three DocTypes, which may improve form rendering and flexibility. [[1]](diffhunk://#diff-221541e0ce35a5b59209e2cc1551225e695e841d5797cde8bb9f7056f04afd25R189) [[2]](diffhunk://#diff-c4e19d30f91c7ce049805c7d63bc67ddc2536e806e9a55270da1dc4c30131c7fR257) [[3]](diffhunk://#diff-ee4b9f7d4da43d2f2b927511d98578e69900e41c088c3e27d836962f688e9a03R165)

**Test and JavaScript file additions:**

* Added placeholder test files for `workday_creation_log` and `workday_generation_log` using `FrappeTestCase`, laying the groundwork for future automated testing. [[1]](diffhunk://#diff-9119530df81191eff60efb13792f8f9bd86c4fcd08cf468e9fbc1a2fc27fbcfdR1-R9) [[2]](diffhunk://#diff-36e23bb2c7523e67fa54ad612a72dfd5e8e66feb1a83656522071f94d7609574R1-R9)

* Added placeholder JavaScript files for `workday_creation_log` and `workday_generation_log` DocTypes, preparing for future client-side scripting. [[1]](diffhunk://#diff-0e208b2e62ffa4cc8b4fd9f054fde24f7f35a15582bcf158f0676e5c3c40f81aR1-R8) [[2]](diffhunk://#diff-835e4ceedad131600f1368283cb563cb88c522638b0d28529322cf3a8ed32b1cR1-R8)