### PR TITLE
Remove Leave Type allocation/LWP filter on Leave Application

### DIFF
--- a/hr_addon/public/js/leave_application.js
+++ b/hr_addon/public/js/leave_application.js
@@ -1,5 +1,31 @@
+function set_unfiltered_leave_type_query(frm) {
+	frm.set_query("leave_type", () => {
+		const filters = {};
+		if (frappe.meta.has_field("Leave Type", "enabled")) {
+			filters.enabled = 1;
+		}
+		return { filters };
+	});
+}
+
 frappe.ui.form.on("Leave Application", {
+	refresh(frm) {
+		set_unfiltered_leave_type_query(frm);
+		frm.trigger("update_overtime_leave_balance_indicator");
+	},
+
 	employee(frm) {
+		set_unfiltered_leave_type_query(frm);
+		frm.trigger("update_overtime_leave_balance_indicator");
+	},
+
+	from_date(frm) {
+		set_unfiltered_leave_type_query(frm);
+		frm.trigger("update_overtime_leave_balance_indicator");
+	},
+
+	to_date(frm) {
+		set_unfiltered_leave_type_query(frm);
 		frm.trigger("update_overtime_leave_balance_indicator");
 	},
 
@@ -25,23 +51,11 @@ frappe.ui.form.on("Leave Application", {
 		}
 	},
 
-	from_date(frm) {
-		frm.trigger("update_overtime_leave_balance_indicator");
-	},
-
-	to_date(frm) {
-		frm.trigger("update_overtime_leave_balance_indicator");
-	},
-
 	half_day(frm) {
 		frm.trigger("update_overtime_leave_balance_indicator");
 	},
 
 	half_day_date(frm) {
-		frm.trigger("update_overtime_leave_balance_indicator");
-	},
-
-	refresh(frm) {
 		frm.trigger("update_overtime_leave_balance_indicator");
 	},
 


### PR DESCRIPTION
Issue - https://git.phamos.eu/suncycle/suncycle/-/work_items/2433
parent - https://git.phamos.eu/suncycle/suncycle/-/work_items/2431

**Summary -**

The Leave Type dropdown on Leave Application was limited to leave types with an active allocation plus LWP types (HRMS make_dashboard logic). That hid other valid leave types (e.g. only Leave Without Pay, Krank, tst, Elternzeit appeared).

This change overrides that client-side filter in hr_addon/public/js/leave_application.js so the dropdown lists all enabled Leave Types (enabled = 1 where the Suncycle custom field exists). The override runs on form refresh and when employee or leave dates change, so HRMS does not re-apply the old filter.

Server-side validation (leave balance, overtime deduct, etc.) is unchanged.